### PR TITLE
Add 5PL regression

### DIFF
--- a/bio_curve_fit/base.py
+++ b/bio_curve_fit/base.py
@@ -5,9 +5,7 @@ from sklearn.base import BaseEstimator
 
 
 class BaseStandardCurve(ABC, BaseEstimator):
-    """
-    Interface for standard curve models.
-    """
+    """Interface for standard curve models."""
 
     # Upper and lower Limits of Detection ("LODs")
     # Estimated Limits of Detection for concentration
@@ -19,6 +17,7 @@ class BaseStandardCurve(ABC, BaseEstimator):
 
     @abstractmethod
     def predict(self, x):
+        """To be overwritten by derived classes."""
         return None
 
     @abstractmethod

--- a/bio_curve_fit/logistic.py
+++ b/bio_curve_fit/logistic.py
@@ -700,6 +700,11 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
             self.guess_S_,
         ]
 
+        param_bounds = [
+            [-np.inf, -np.inf, -np.inf, -np.inf, 0],
+            [np.inf, np.inf, np.inf, np.inf, 10],
+        ]
+
         curve_fit_kwargs = {
             "f": self._five_param_logistic,
             "xdata": x_data,
@@ -708,6 +713,7 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
             "maxfev": 10000,
             "sigma": weights,
             "absolute_sigma": absolute_sigma,
+            "bounds": param_bounds,
         }
 
         # overwrite parameters with any kwargs passed in
@@ -801,13 +807,13 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
         if isinstance(y, list):
             y = np.array(y, dtype=float)
 
-        z = ((self.A_ - self.D_) / (y - self.D_)) - 1  # type: ignore
+        z = (self.A_ - self.D_) / (y - self.D_)  # type: ignore
 
-        term1 = (np.sign(z) * np.abs(z)) ** 1 / self.S_ - 1
+        term1 = (np.sign(z) * np.abs(z)) ** (1 / self.S_) - 1
 
         # For addressing fractional powers of negative numbers, np.sign(z) * np.abs(z) used rather than z
         # https://stackoverflow.com/questions/45384602/numpy-runtimewarning-invalid-value-encountered-in-power
-        x = self.C_ * term1**1 / self.B_  # type: ignore
+        x = self.C_ * term1 ** (1 / self.B_)  # type: ignore
 
         if enforce_limits:
             if isinstance(y, (np.ndarray, pd.Series)):

--- a/bio_curve_fit/logistic.py
+++ b/bio_curve_fit/logistic.py
@@ -5,8 +5,9 @@ from typing import Iterable, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 from scipy.optimize import curve_fit
-from sklearn.base import RegressorMixin
 from scipy.stats import skew
+from sklearn.base import RegressorMixin
+
 from .base import BaseStandardCurve
 
 
@@ -99,7 +100,7 @@ class FourPLLogistic(RegressorMixin, BaseStandardCurve):
 
         Parameters
         ----------
-        deep: bool, optional 
+        deep: bool, optional
             If True, return the LODs as well. Defaults to False.
 
         Returns
@@ -182,9 +183,9 @@ class FourPLLogistic(RegressorMixin, BaseStandardCurve):
         """
         x_indexed_y_data = pd.DataFrame({"x": x_data, "y": y_data}).set_index("x")
         # remove zeros from x_data
-        x_indexed_y_data = x_indexed_y_data[x_indexed_y_data.index > 0]
-        x_min = np.min(x_indexed_y_data.index)
-        x_max = np.max(x_indexed_y_data.index)
+        x_indexed_y_data = x_indexed_y_data[x_indexed_y_data.index > 0]  # type: ignore
+        x_min = np.min(x_indexed_y_data.index)  # type: ignore
+        x_max = np.max(x_indexed_y_data.index)  # type: ignore
         bottom_std_dev = x_indexed_y_data.loc[x_min, "y"].std()
         top_std_dev = x_indexed_y_data.loc[x_max, "y"].std()
 
@@ -399,6 +400,7 @@ class FourPLLogistic(RegressorMixin, BaseStandardCurve):
         self._check_fit()
         return self._four_param_logistic(x_data, self.A_, self.B_, self.C_, self.D_)
 
+
 class FivePLLogistic(RegressorMixin, BaseStandardCurve):
     r"""
 
@@ -465,7 +467,13 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
         self.slope_guess_num_points_to_use = slope_guess_num_points_to_use
 
     def _check_fit(self):
-        if self.A_ is None or self.B_ is None or self.C_ is None or self.D_ is None or self.S_ is None:
+        if (
+            self.A_ is None
+            or self.B_ is None
+            or self.C_ is None
+            or self.D_ is None
+            or self.S_ is None
+        ):
             raise Exception(
                 "Model is not fit yet. Please call 'fit' with appropriate data"
                 " or initialize the model object with non-null parameters."
@@ -530,7 +538,7 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
         # For addressing fractional powers of negative numbers
         # https://stackoverflow.com/questions/45384602/numpy-runtimewarning-invalid-value-encountered-in-power
         z = (np.sign(x / C) * np.abs(x / C)) ** B
-        denominator = (1.0 + z)**S
+        denominator = (1.0 + z) ** S
 
         return ((A - D) / denominator) + D
 
@@ -580,9 +588,9 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
         """
         x_indexed_y_data = pd.DataFrame({"x": x_data, "y": y_data}).set_index("x")
         # remove zeros from x_data
-        x_indexed_y_data = x_indexed_y_data[x_indexed_y_data.index > 0]
-        x_min = np.min(x_indexed_y_data.index)
-        x_max = np.max(x_indexed_y_data.index)
+        x_indexed_y_data = x_indexed_y_data[x_indexed_y_data.index > 0]  # type: ignore
+        x_min = np.min(x_indexed_y_data.index)  # type: ignore
+        x_max = np.max(x_indexed_y_data.index)  # type: ignore
         bottom_std_dev = x_indexed_y_data.loc[x_min, "y"].std()
         top_std_dev = x_indexed_y_data.loc[x_max, "y"].std()
 
@@ -598,10 +606,9 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
     @staticmethod
     def _tangent_line_at_midpoint(x, A, B, C, D, S):
         """Line with slope = (Derivative of the 5PL curve evaluated at C) and passing through the point C."""
-
-        term1 = D + (A-D)/2**S
-        term2 = (A-D) * S * B / (2**(S+1)*C)
-        term3 = x-C
+        term1 = D + (A - D) / 2**S
+        term2 = (A - D) * S * B / (2 ** (S + 1) * C)
+        term3 = x - C
         return term1 - term2 * term3
 
     def tangent_line_at_midpoint(self, x):
@@ -610,14 +617,15 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
         This is an alternate way to define the linear range of the curve, that is, the part of the curve where it is approximately linear.
         """
         self._check_fit()
-        return self._tangent_line_at_midpoint(x, self.A_, self.B_, self.C_, self.D_, self.S_)
+        return self._tangent_line_at_midpoint(
+            x, self.A_, self.B_, self.C_, self.D_, self.S_
+        )
 
     @staticmethod
     def _tangent_line_at_arbitrary_point(x, g, A, B, C, D, S):
         """Return y value of line with slope = (Derivative of the 5PL curve evaluated at g) and passing through the point (g, f(g))."""
-
-        derivative_at_g = (
-                (-1 * (A-D) * S * B * (g/C) ** (B-1) )/ (C*(1+(g/C)**B)**(S+1))
+        derivative_at_g = (-1 * (A - D) * S * B * (g / C) ** (B - 1)) / (
+            C * (1 + (g / C) ** B) ** (S + 1)
         )
 
         line_with_slope_at_g = derivative_at_g * (
@@ -684,7 +692,13 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
         self.guess_D_ = np.max(y_data)  # type: ignore
         self.guess_S_ = 1
 
-        initial_guess = [self.guess_A_, self.guess_B_, self.guess_C_, self.guess_D_, self.guess_S_]
+        initial_guess = [
+            self.guess_A_,
+            self.guess_B_,
+            self.guess_C_,
+            self.guess_D_,
+            self.guess_S_,
+        ]
 
         curve_fit_kwargs = {
             "f": self._five_param_logistic,
@@ -712,22 +726,24 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
         """Jacobian matrix of the 5PL function with respect to A, B, C, D, S."""
         z = (x_data / C) ** B
 
-        partial_A = 1.0 / (1.0 + z)**S
+        partial_A = 1.0 / (1.0 + z) ** S
 
-        partial_B_num = -(A-D)*S*z*np.log(np.maximum(x_data / C, np.finfo(float).eps))
-        partial_B_denom = (1 + z)**(S+1)
-        partial_B = partial_B_num/partial_B_denom
+        partial_B_num = (
+            -(A - D) * S * z * np.log(np.maximum(x_data / C, np.finfo(float).eps))
+        )
+        partial_B_denom = (1 + z) ** (S + 1)
+        partial_B = partial_B_num / partial_B_denom
 
-        partial_C_num = -(A-D) * S * B * z
-        partial_C_denom = C * (1 + z)**(S+1)
-        partial_C = partial_C_num/partial_C_denom
+        partial_C_num = -(A - D) * S * B * z
+        partial_C_denom = C * (1 + z) ** (S + 1)
+        partial_C = partial_C_num / partial_C_denom
 
-        partial_D = 1.0 - 1.0 / (1.0 + z)**S
+        partial_D = 1.0 - 1.0 / (1.0 + z) ** S
 
-        partial_S_num = -(A-D) * np.log(1 + z)
-        partial_S_denom = (1 + z)**S
+        partial_S_num = -(A - D) * np.log(1 + z)
+        partial_S_denom = (1 + z) ** S
 
-        partial_S = partial_S_num/partial_S_denom
+        partial_S = partial_S_num / partial_S_denom
 
         # Jacobian matrix
         J = np.array([partial_A, partial_B, partial_C, partial_D, partial_S]).T
@@ -787,11 +803,11 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
 
         z = ((self.A_ - self.D_) / (y - self.D_)) - 1  # type: ignore
 
-        term1 = (np.sign(z) * np.abs(z))**1/self.S_ - 1
+        term1 = (np.sign(z) * np.abs(z)) ** 1 / self.S_ - 1
 
         # For addressing fractional powers of negative numbers, np.sign(z) * np.abs(z) used rather than z
         # https://stackoverflow.com/questions/45384602/numpy-runtimewarning-invalid-value-encountered-in-power
-        x = self.C_ * term1 ** 1/self.B_  # type: ignore
+        x = self.C_ * term1**1 / self.B_  # type: ignore
 
         if enforce_limits:
             if isinstance(y, (np.ndarray, pd.Series)):
@@ -816,4 +832,6 @@ class FivePLLogistic(RegressorMixin, BaseStandardCurve):
             iterable: y data points
         """
         self._check_fit()
-        return self._five_param_logistic(x_data, self.A_, self.B_, self.C_, self.D_, self.S_)
+        return self._five_param_logistic(
+            x_data, self.A_, self.B_, self.C_, self.D_, self.S_
+        )

--- a/bio_curve_fit/logistic.py
+++ b/bio_curve_fit/logistic.py
@@ -398,3 +398,420 @@ class FourPLLogistic(RegressorMixin, BaseStandardCurve):
         """
         self._check_fit()
         return self._four_param_logistic(x_data, self.A_, self.B_, self.C_, self.D_)
+
+class FivePLLogistic(RegressorMixin, BaseStandardCurve):
+    r"""
+
+    Five Parameter Logistic (5PL) model.
+
+    The 4PL model is a sigmoidal curve that is defined by the following equation:
+
+    .. math::
+        f(x) = \\frac{A - D}{1 + (\\frac{x}{C})^B} + D
+
+    Where:
+        - A is the minimum asymptote
+        - B is the Hill's slope
+        - C is the inflection point (EC50)
+        - D is the maximum asymptote
+
+    The 4PL model is commonly used in bioassays, such as ELISA, where the response signal is
+    proportional to the concentration of the analyte being measured. The 4PL model is used to
+    fit a standard curve, which is a plot of the response signal against the concentration of
+    known standards. The standard curve is then used to estimate the concentration of unknown
+    samples based on their response signal.
+    """
+
+    def __init__(
+        self,
+        A=None,
+        B=None,
+        C=None,
+        D=None,
+        S=None,
+        LLOD=None,
+        ULOD=None,
+        ULOD_y=None,
+        LLOD_y=None,
+        slope_direction_positive: Optional[bool] = None,
+        slope_guess_num_points_to_use: int = 3,
+    ):
+        # A is the minimum asymptote
+        self.A_ = A
+        # B is the Hill's slope
+        self.B_ = B
+        # C is the inflection point (EC50)
+        self.C_ = C
+        # D is the maximum asymptote
+        self.D_ = D
+        # S is the asymmetry factor. S = 1 is a symmetric curve.
+        self.S_ = S
+        self.cov_ = None
+        # Initial guesses used when fitting the curve
+        self.guess_A_ = None
+        self.guess_B_ = None
+        self.guess_C_ = None
+        self.guess_D_ = None
+        self.guess_S_ = None
+        # Estimated Limits of Detection for response signal
+        self.LLOD_y_ = LLOD_y
+        self.ULOD_y_ = ULOD_y
+        # Estimated Limits of Detection for concentration
+        self.LLOD_ = LLOD
+        self.ULOD_ = ULOD
+        self.slope_direction_positive = slope_direction_positive
+        self.slope_guess_num_points_to_use = slope_guess_num_points_to_use
+
+    def _check_fit(self):
+        if self.A_ is None or self.B_ is None or self.C_ is None or self.D_ is None or self.S_ is None:
+            raise Exception(
+                "Model is not fit yet. Please call 'fit' with appropriate data"
+                " or initialize the model object with non-null parameters."
+            )
+
+    def semi_log_linear_range_of_response(self) -> Tuple[float, float]:
+        """
+        Return the response range where the curve is approximately linear in a semi-log plot.
+
+        That is, it returns the lower and upper limit y-values where the curve will "look" linear
+        when plotted on a log scaled x-axis (usually concentration) and a linear y-axis (usually response).
+
+        Follows Sebaugh, Jeanne & McCray, P.. (2003). Defining the linear portion of a sigmoid-shaped curve: Bend points. Pharmaceutical Statistics - PHARM STAT. 2. 167-174. 10.1002/pst.62. See the pdf in the references folder in this repo, or https://www.researchgate.net/publication/246918700_Defining_the_linear_portion_of_a_sigmoid-shaped_curve_Bend_points
+
+
+        """
+        K = 4.680498579
+        A, B, C, D, S = self.get_params().values()
+        y_bend_lower = (A - D) / (1 + 1 / K) + D  # type: ignore
+        y_bend_upper = (A - D) / (1 + K) + D  # type: ignore
+        return y_bend_lower, y_bend_upper
+
+    def get_params(self, deep=False):
+        """
+        Get the parameters of the 5PL model, optionally including the estimated LODs.
+
+        Parameters
+        ----------
+        deep: bool, optional
+            If True, return the LODs as well. Defaults to False.
+
+        Returns
+        -------
+        dict:
+            Dictionary containing the parameters of the 4PL model. If `deep` is True, the dictionary will also contain the estimated LODs.
+        """
+        self._check_fit()
+        if deep:
+            return {
+                "A": self.A_,
+                "B": self.B_,
+                "C": self.C_,
+                "D": self.D_,
+                "S": self.S_,
+                "LLOD": self.LLOD_,
+                "ULOD": self.ULOD_,
+                "ULOD_y": self.ULOD_y_,
+                "LLOD_y": self.LLOD_y_,
+            }
+        else:
+            return {
+                "A": self.A_,
+                "B": self.B_,
+                "C": self.C_,
+                "D": self.D_,
+                "S": self.S_,
+            }
+
+    @staticmethod
+    def _five_param_logistic(x, A, B, C, D, S):
+        """5 Parameter Logistic (5PL) model."""
+        # For addressing fractional powers of negative numbers
+        # https://stackoverflow.com/questions/45384602/numpy-runtimewarning-invalid-value-encountered-in-power
+        z = (np.sign(x / C) * np.abs(x / C)) ** B
+        denominator = (1.0 + z)**S
+
+        return ((A - D) / denominator) + D
+
+    @staticmethod
+    def inverse_variance_weight_function(y_data):
+        """
+        Weight function for weighting residuals by 1/y^2 in `scipy.optimize.curve_fit`.
+
+        Parameters
+        ----------
+            y_data: y data points
+        """
+        # To avoid division by zero, add a small constant to y_data.
+        return y_data + np.finfo(float).eps
+
+    def _calculate_lod_replicate_variance(
+        self,
+        x_data,
+        y_data,
+        lower_std_dev_multiplier: float = 2.5,
+        upper_std_dev_multiplier: float = 0.0,
+    ):
+        """Calculate the Lower and Upper Limits of Detection (LLOD and ULOD).
+
+        Uses variance of replicate max and min concentration standards. It ignores
+        zero concentration standards. If there are no replicates, the standard
+        deviation zero. Possible TODO: sometimes a minimum variance is used in other software.
+
+        In the notation below we assume the response signal is the Y-axis and the
+        concentration is the X-axis.
+
+        Example: Two replicates of the lowest concentration standard (conc=1.0 pg/ml)
+        have standard deviation of 100 across their responses. LLOD will be `model.predict
+        (1.0) + 100 * 2.5` where 2.5 is the `lower_std_dev_multiplier` parameter.
+
+        Parameters
+        ----------
+        x_data: x data points
+        y_data: y data points
+        lower_std_dev_multiplier: Multiplier how many standard deviations to add to the lowest calibration point to get the LLOD.
+        upper_std_dev_multiplier: Multiplier how many standard deviations to subtract from the highest calibration point to get the ULOD.
+
+        Returns
+        -------
+        tuple[float, float, float, float]:
+            the LLOD and ULOD, and the corresponding x-values.
+        """
+        x_indexed_y_data = pd.DataFrame({"x": x_data, "y": y_data}).set_index("x")
+        # remove zeros from x_data
+        x_indexed_y_data = x_indexed_y_data[x_indexed_y_data.index > 0]
+        x_min = np.min(x_indexed_y_data.index)
+        x_max = np.max(x_indexed_y_data.index)
+        bottom_std_dev = x_indexed_y_data.loc[x_min, "y"].std()
+        top_std_dev = x_indexed_y_data.loc[x_max, "y"].std()
+
+        # Calculate LLOD and ULOD of RESPONSE SIGNAL
+        llod = self.predict(x_min) + (lower_std_dev_multiplier * bottom_std_dev)
+        ulod = self.predict(x_max) - (upper_std_dev_multiplier * top_std_dev)
+
+        # Calculate the limits of detection for CONCENTRATION
+        llod_x = self.predict_inverse(llod)
+        ulod_x = self.predict_inverse(ulod)
+        return llod_x, ulod_x, llod, ulod
+
+    @staticmethod
+    def _tangent_line_at_midpoint(x, A, B, C, D, S):
+        """Line with slope = (Derivative of the 5PL curve evaluated at C) and passing through the point C."""
+
+        term1 = D + (A-D)/2**S
+        term2 = (A-D) * S * B / (2**(S+1)*C)
+        term3 = x-C
+        return term1 - term2 * term3
+
+    def tangent_line_at_midpoint(self, x):
+        """Return y value of the tangent line at the inflection point (C) of the 4PL curve.
+
+        This is an alternate way to define the linear range of the curve, that is, the part of the curve where it is approximately linear.
+        """
+        self._check_fit()
+        return self._tangent_line_at_midpoint(x, self.A_, self.B_, self.C_, self.D_, self.S_)
+
+    @staticmethod
+    def _tangent_line_at_arbitrary_point(x, g, A, B, C, D, S):
+        """Return y value of line with slope = (Derivative of the 5PL curve evaluated at g) and passing through the point (g, f(g))."""
+
+        derivative_at_g = (
+                (-1 * (A-D) * S * B * (g/C) ** (B-1) )/ (C*(1+(g/c)**b)**(S+1))
+        )
+
+        print(derivative_at_g)
+        line_with_slope_at_g = derivative_at_g * (
+            x - g
+        ) + FivePLLogistic._five_param_logistic(g, A, B, C, D, S)
+
+        return line_with_slope_at_g
+
+    def tangent_line_at_arbitrary_point(self, x, g):
+        """Return the f(x) where f is the line tangent to the 4PL curve at the point g."""
+        self._check_fit()
+        return FivePLLogistic._tangent_line_at_arbitrary_point(
+            x, g, self.A_, self.B_, self.C_, self.D_, self.S_
+        )
+
+    def fit(self, x_data, y_data, weight_func=None, LOD_func=None, **kwargs):
+        """
+        Fit the 4 Parameter Logistic (4PL) model.
+
+        x_data: x data points
+        y_data: y data points
+        weight_func: optional Function that calculates weights from y_data. This is
+            passed into the `curve_fit` function where the function minimized is `sum
+            ((r / weight_func(y_data)) ** 2)` where r is the residuals.
+            Thus for a typical 1/y^2 weighting, `weight_func` should be `lambda
+            y_data: y_data`
+        """
+        x_data = np.float64(x_data)
+        y_data = np.float64(y_data)
+        df_data = pd.DataFrame({"x": x_data, "y": y_data})
+        df_data.sort_values(by="x", inplace=True)
+
+        if LOD_func is None:
+            # default LOD_func is to use replicate variance
+            LOD_func = self._calculate_lod_replicate_variance
+
+        absolute_sigma = False
+        weights = None
+        if weight_func is not None:
+            weights = weight_func(y_data)
+            absolute_sigma = True
+
+        # Initial guess for the parameters
+        self.guess_A_ = np.min(y_data)  # type: ignore
+        if self.slope_direction_positive is not None:
+            self.guess_B_ = 1.0 if self.slope_direction_positive else -1.0
+        else:
+            # type: ignore
+            self.guess_B_ = (
+                1.0
+                if np.mean(
+                    df_data.iloc[: np.minimum(self.slope_guess_num_points_to_use, len(df_data))][  # type: ignore
+                        "y"
+                    ]
+                )
+                < np.mean(
+                    df_data.iloc[-np.minimum(self.slope_guess_num_points_to_use, len(df_data)) :][  # type: ignore
+                        "y"
+                    ]
+                )
+                else -1.0
+            )
+        self.guess_C_ = np.mean(x_data)  # type: ignore
+        self.guess_D_ = np.max(y_data)  # type: ignore
+        self.guess_S_ = 1
+        initial_guess = [self.guess_A_, self.guess_B_, self.guess_C_, self.guess_D_, self.guess_S_]
+
+        curve_fit_kwargs = {
+            "f": self._five_param_logistic,
+            "xdata": x_data,
+            "ydata": y_data,
+            "p0": initial_guess,
+            "maxfev": 10000,
+            "sigma": weights,
+            "absolute_sigma": absolute_sigma,
+        }
+
+        # overwrite parameters with any kwargs passed in
+        for k, v in kwargs.items():
+            curve_fit_kwargs[k] = v
+
+        # Perform the curve fit
+        params, cov = curve_fit(**curve_fit_kwargs)
+        self.A_, self.B_, self.C_, self.D_, self.S_ = params
+        self.cov_ = cov
+        self.LLOD_, self.ULOD_, self.LLOD_y_, self.ULOD_y_ = LOD_func(x_data, y_data)
+        return self
+
+    @staticmethod
+    def jacobian(x_data, A, B, C, D, S):
+        """Jacobian matrix of the 5PL function with respect to A, B, C, D, S."""
+        z = (x_data / C) ** B
+
+        partial_A = 1.0 / (1.0 + z)**S
+
+        partial_B_num = -(A-D)*S*Z*np.log(np.maximum(x_data / C, np.finfo(float).eps))
+        partial_B_denom = (1 + z)**(S+1)
+        partial_B = partial_B_num/partial_B_denom
+
+        partial_C_num = -(A-D) * S * B * Z
+        partial_C_denom = C * (1 + z)**(S+1)
+        partial_C = partial_C_num/partial_C_denom
+
+        partial_D = 1.0 - 1.0 / (1.0 + z)**S
+
+        partial_S_num = -(A-D) * np.log(1 + z)
+        partial_S_denom = (1 + z)**S
+
+        partial_S = partial_S_num/partial_S_denom
+
+        # Jacobian matrix
+        J = np.array([partial_A, partial_B, partial_C, partial_D, partial_S]).T
+        return J
+
+    def predict_confidence_band(self, x_data):
+        """
+        Predict confidence bands of data points.
+
+        See:
+            https://www.graphpad.com/guides/prism/latest/curve-fitting/reg_graphing_confidence_and_predic.htm
+            https://www.graphpad.com/guides/prism/latest/curve-fitting/reg_how_confidence_and_prediction_.htm
+            https://stats.stackexchange.com/questions/15423/how-to-compute-prediction-bands-for-non-linear-regression
+
+        """
+        if self.cov_ is None:
+            raise Exception(
+                "Covariance matrix is not available. Please call 'fit' with appropriate data."
+            )
+        J = self.jacobian(x_data, self.A_, self.B_, self.C_, self.D_, self.S_)
+        pred_var = np.sum((J @ self.cov_) * J, axis=1)
+
+        return np.sqrt(pred_var)
+
+    def predict_prediction_band(self, x_data, y_data):
+        """Predict prediction bands of data points.
+
+        TODO: still need to double-check the math here.
+        """
+        ss = (y_data - self.predict(x_data)) ** 2
+        df = len(x_data) - 5  # 5 parameters
+
+        return np.sqrt(self.predict_confidence_band(x_data) ** 2 * ss / df)
+
+    def predict_inverse(
+        self, y: Union[float, int, np.ndarray, Iterable[float]], enforce_limits=True
+    ):
+        """Inverse 5 Parameter Logistic (5PL) model.
+
+        Used for calculating the x-value for a given y-value.
+        Usually, standard curves are fitted using concentration as x-values and response as
+        y-values, so that variance in response is modeled for a given known concentration.
+        But for samples of unknown concentration, we want to get the concentration as given
+        response, which is what this function does.
+
+        Parameters
+        ----------
+        y: float or iterable
+            The response value for which the corresponding x-value will be calculated.
+        enforce_limits: bool
+            If True, return np.nan for y-values above the maximum asymptote (D) of the curve, and 0 for y-values below the minimum asymptote (A) of the curve.
+
+        """
+        self._check_fit()
+        if isinstance(y, list):
+            y = np.array(y, dtype=float)
+
+        z = ((self.A_ - self.D_) / (y - self.D_)) - 1  # type: ignore
+
+        term1 = (np.sign(z) * np.abs(z))**1/self.S_ - 1
+
+        # For addressing fractional powers of negative numbers, np.sign(z) * np.abs(z) used rather than z
+        # https://stackoverflow.com/questions/45384602/numpy-runtimewarning-invalid-value-encountered-in-power
+        x = self.C_ * term1 ** 1/self.B_  # type: ignore
+
+        if enforce_limits:
+            if isinstance(y, (np.ndarray, pd.Series)):
+                x[y > self.D_] = np.nan  # type: ignore
+                x[y < self.A_] = 0  # type: ignore
+            elif isinstance(y, (int, float)):
+                if y > self.D_:  # type: ignore
+                    return np.nan
+                elif y < self.A_:  # type: ignore
+                    return 0
+        return x
+
+    def predict(self, x_data):
+        """Predict y-values using the 5PL model.
+
+        Parameters
+        ----------
+            x_data (iterable): x data points
+
+        Returns
+        -------
+            iterable: y data points
+        """
+        self._check_fit()
+        return self._five_param_logistic(x_data, self.A_, self.B_, self.C_, self.D_, self.S_)

--- a/bio_curve_fit/plotting.py
+++ b/bio_curve_fit/plotting.py
@@ -1,7 +1,6 @@
 import io
 from typing import Tuple
 
-import matplotlib
 import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,7 +27,8 @@ def plot_standard_curve(
     """
     Generate a plot of the data and the fitted curve with customizable plotting parameters.
 
-    Parameters:
+    Parameters
+    ----------
     - x_data (iterable): X-axis data points.
     - y_data (iterable | None): Y-axis data points corresponding to x_data. Can set this to None if you only want to plot the fitted curve for a given range of x-values specified in `x_data`.
     - fitted_model (BaseStandardCurve): A fitted model instance that provides prediction and LLOD/ULOD values.
@@ -42,7 +42,8 @@ def plot_standard_curve(
     - ulod_kwargs (dict, optional): Keyword arguments for the axhline function for the Upper Limit of Detection line. Default is {'color': 'blue', 'linestyle': '--', 'label': 'ULOD'}.
     - plot_kwargs (dict, optional): General keyword arguments for further plot customizations. This can include 'title_kwargs' for title properties and 'savefig_kwargs' for savefig properties, 'formatter' for the x-axis formatter (Default is Log), and 'xscale' and 'yscale' for the plot scale (Default is 'log').
 
-    Returns:
+    Returns
+    -------
     - fig, ax: The matplotlib figure and axes objects.
 
     Example Usage:
@@ -51,7 +52,6 @@ def plot_standard_curve(
 
     This function allows extensive customization of the plot's appearance by adjusting properties of the curve, data points, LLOD line, ULOD line, and overall plot aesthetics through various keyword arguments. For more advanced customization, consider using plot_standard_curve_figure instead, which returns the figure and axes objects for further modification.
     """
-
     fig, ax = plot_standard_curve_figure(
         x_data,
         y_data,
@@ -88,7 +88,8 @@ def plot_standard_curve_figure(
     **plot_kwargs  # kwargs for general plot adjustments
 ) -> Tuple[matplotlib.figure.Figure, plt.Axes]:
     """
-    Same as plot_standard_curve, but returns the figure and axes objects instead of saving the plot to a file
+
+    Plot a standard curve, similar to plot_standard_curve, but returns the figure and axes objects instead of saving the plot to a file
     for easier customization and further modification.
 
     Example Usage:
@@ -105,8 +106,8 @@ def plot_standard_curve_figure(
     # Adjust text labels to avoid overlap
     adjust_text(texts, ax=ax)
     ```
-    """
 
+    """
     # Default keyword argument dictionaries
     if curve_kwargs is None:
         curve_kwargs = {"label": "Fitted curve", "color": "red"}
@@ -119,12 +120,13 @@ def plot_standard_curve_figure(
 
     fig, ax = plt.subplots()
 
-    ax.set_xscale(plot_kwargs.get("xscale", "log"))
-    ax.set_yscale(plot_kwargs.get("yscale", "log"))
+    ax.set_xscale(plot_kwargs.get("xscale", "log"))  # type: ignore
+    ax.set_yscale(plot_kwargs.get("yscale", "log"))  # type: ignore
 
     EPSILON = 0.01
     x_min = np.log10(max(min(x_data), EPSILON))
     x_max = max(x_data) * 2
+
     x = np.logspace(x_min, np.log10(x_max), 100)  # type: ignore
     y_pred = fitted_model.predict(x)
 
@@ -132,10 +134,10 @@ def plot_standard_curve_figure(
     if y_data is not None:
         data = pd.DataFrame({"x": x_data, "y": y_data})
         filtered_data = data[data["x"] > 0]
-        ax.scatter(filtered_data["x"], filtered_data["y"], **data_kwargs)
+        ax.scatter(filtered_data["x"], filtered_data["y"], **data_kwargs)  # type: ignore
 
     formatter = plot_kwargs.get("formatter", LogFormatter())
-    ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.set_major_formatter(formatter)  # type: ignore
     ax.set_xlabel(x_label)
     ax.set_ylabel(y_label)
     ax.set_title(title, **plot_kwargs.get("title_kwargs", {}))

--- a/examples/five_pl_logistic/five_pl_fit.ipynb
+++ b/examples/five_pl_logistic/five_pl_fit.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/Ganymede-Bio/bio-curve-fit/blob/main/examples/four_pl_logistic/four_pl_fit.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/Ganymede-Bio/bio-curve-fit/blob/main/examples/five_pl_logistic/five_pl_fit.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]

--- a/examples/five_pl_logistic/five_pl_fit.ipynb
+++ b/examples/five_pl_logistic/five_pl_fit.ipynb
@@ -1,0 +1,934 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/Ganymede-Bio/bio-curve-fit/blob/main/examples/four_pl_logistic/four_pl_fit.ipynb\">\n",
+    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T07:44:50.804655Z",
+     "start_time": "2024-11-20T07:44:50.216881Z"
+    }
+   },
+   "source": [
+    "! pip install bio-curve-fit"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: bio-curve-fit in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (0.2.2)\r\n",
+      "Requirement already satisfied: adjusttext<2.0.0,>=1.2.0 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from bio-curve-fit) (1.2.0)\r\n",
+      "Requirement already satisfied: matplotlib>=3.7.1 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from bio-curve-fit) (3.7.5)\r\n",
+      "Requirement already satisfied: pandas>=1.5.3 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from bio-curve-fit) (2.0.3)\r\n",
+      "Requirement already satisfied: scikit-learn>=1.2.2 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from bio-curve-fit) (1.3.2)\r\n",
+      "Requirement already satisfied: numpy in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from adjusttext<2.0.0,>=1.2.0->bio-curve-fit) (1.24.4)\r\n",
+      "Requirement already satisfied: scipy in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from adjusttext<2.0.0,>=1.2.0->bio-curve-fit) (1.9.3)\r\n",
+      "Requirement already satisfied: contourpy>=1.0.1 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from matplotlib>=3.7.1->bio-curve-fit) (1.1.1)\r\n",
+      "Requirement already satisfied: cycler>=0.10 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from matplotlib>=3.7.1->bio-curve-fit) (0.12.1)\r\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from matplotlib>=3.7.1->bio-curve-fit) (4.53.1)\r\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from matplotlib>=3.7.1->bio-curve-fit) (1.4.5)\r\n",
+      "Requirement already satisfied: packaging>=20.0 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from matplotlib>=3.7.1->bio-curve-fit) (24.1)\r\n",
+      "Requirement already satisfied: pillow>=6.2.0 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from matplotlib>=3.7.1->bio-curve-fit) (10.4.0)\r\n",
+      "Requirement already satisfied: pyparsing>=2.3.1 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from matplotlib>=3.7.1->bio-curve-fit) (3.1.4)\r\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from matplotlib>=3.7.1->bio-curve-fit) (2.9.0.post0)\r\n",
+      "Requirement already satisfied: pytz>=2020.1 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from pandas>=1.5.3->bio-curve-fit) (2024.1)\r\n",
+      "Requirement already satisfied: tzdata>=2022.1 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from pandas>=1.5.3->bio-curve-fit) (2024.1)\r\n",
+      "Requirement already satisfied: joblib>=1.1.1 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from scikit-learn>=1.2.2->bio-curve-fit) (1.4.2)\r\n",
+      "Requirement already satisfied: threadpoolctl>=2.0.0 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from scikit-learn>=1.2.2->bio-curve-fit) (3.5.0)\r\n",
+      "Requirement already satisfied: six>=1.5 in /Users/nickflores_ganymede/Library/Caches/pypoetry/virtualenvs/bio-curve-fit-WuAbQiBo-py3.11/lib/python3.11/site-packages (from python-dateutil>=2.7->matplotlib>=3.7.1->bio-curve-fit) (1.16.0)\r\n",
+      "\r\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m24.3.1\u001B[0m\r\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\r\n"
+     ]
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T07:44:52.880521Z",
+     "start_time": "2024-11-20T07:44:50.807560Z"
+    }
+   },
+   "source": [
+    "import pandas as pd\n",
+    "import io\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt\n",
+    "from bio_curve_fit.logistic import FourPLLogistic, FivePLLogistic\n",
+    "from bio_curve_fit.plotting import plot_standard_curve "
+   ],
+   "outputs": [],
+   "execution_count": 2
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Fitting a Five-Parameter Logistic Model to Create a Standard Curve using `bio-curve-fit`"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "For the purposes of demonstration, let's imagine we have 20 samples with a known concentration (standards) of an analyte. We've tested these standards, in triplicate, on an appropriate instrument and recorded the observed response signal. "
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T08:16:56.733654Z",
+     "start_time": "2024-11-20T08:16:56.726548Z"
+    }
+   },
+   "source": [
+    "standard_curve_csv = \"\"\"\n",
+    "known_concentration,instrument_response\n",
+    "0.01,0.002069117990872958\n",
+    "0.01,0.0020132494933515024\n",
+    "0.01,0.0021169840704374815\n",
+    "0.01438449888287663,0.001959532926455008\n",
+    "0.01438449888287663,0.0019884553193551735\n",
+    "0.01438449888287663,0.0019444061051506441\n",
+    "0.0206913808111479,0.0019060618132396786\n",
+    "0.0206913808111479,0.001948195812428334\n",
+    "0.0206913808111479,0.0018817446798727263\n",
+    "0.029763514416313176,0.0020199075226226327\n",
+    "0.029763514416313176,0.00208893443732371\n",
+    "0.029763514416313176,0.0020935290065508014\n",
+    "0.04281332398719394,0.00232136833694934\n",
+    "0.04281332398719394,0.0023468274954318875\n",
+    "0.04281332398719394,0.0023670255256337098\n",
+    "0.06158482110660264,0.002350039420066734\n",
+    "0.06158482110660264,0.0024226848713439883\n",
+    "0.06158482110660264,0.002328199275919817\n",
+    "0.08858667904100823,0.0034268951061987517\n",
+    "0.08858667904100823,0.0033724552342330205\n",
+    "0.08858667904100823,0.003333991357245253\n",
+    "0.12742749857031335,0.005976982077588455\n",
+    "0.12742749857031335,0.005894796802448098\n",
+    "0.12742749857031335,0.006183810672175324\n",
+    "0.18329807108324356,0.01429016019812947\n",
+    "0.18329807108324356,0.014007072131872945\n",
+    "0.18329807108324356,0.01451425437925086\n",
+    "0.26366508987303583,0.03919501065794866\n",
+    "0.26366508987303583,0.03816319608099027\n",
+    "0.26366508987303583,0.04029788595266494\n",
+    "0.37926901907322497,0.11012486126580442\n",
+    "0.37926901907322497,0.10773997727674114\n",
+    "0.37926901907322497,0.11289584492731791\n",
+    "0.5455594781168517,0.28788349523919826\n",
+    "0.5455594781168517,0.2874878807698649\n",
+    "0.5455594781168517,0.2806375306078681\n",
+    "0.7847599703514611,0.6293705171187065\n",
+    "0.7847599703514611,0.6292218560816774\n",
+    "0.7847599703514611,0.6107084160933515\n",
+    "1.1288378916846884,1.0942268483928872\n",
+    "1.1288378916846884,1.0779629449846204\n",
+    "1.1288378916846884,1.1151270114916647\n",
+    "1.623776739188721,1.5682314346793895\n",
+    "1.623776739188721,1.544967383412808\n",
+    "1.623776739188721,1.540068595980988\n",
+    "2.3357214690901213,1.9810187452329917\n",
+    "2.3357214690901213,1.9494269607495571\n",
+    "2.3357214690901213,1.9408931920431431\n",
+    "3.359818286283781,2.3179681138726\n",
+    "3.359818286283781,2.395117528971509\n",
+    "3.359818286283781,2.2504633190845866\n",
+    "4.832930238571752,2.5871131435953965\n",
+    "4.832930238571752,2.6507642395678666\n",
+    "4.832930238571752,2.6777030295287907\n",
+    "6.951927961775605,2.8003648496549087\n",
+    "6.951927961775605,2.8517696956036693\n",
+    "6.951927961775605,2.8775895443122463\n",
+    "10.0,2.968849253649377\n",
+    "10.0,3.032484862793274\n",
+    "10.0,2.896894467504049\n",
+    "\"\"\"\n",
+    "\n",
+    "df = pd.read_csv(io.StringIO(standard_curve_csv))\n",
+    "df"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "    known_concentration  instrument_response\n",
+       "0              0.010000             0.002069\n",
+       "1              0.010000             0.002013\n",
+       "2              0.010000             0.002117\n",
+       "3              0.014384             0.001960\n",
+       "4              0.014384             0.001988\n",
+       "5              0.014384             0.001944\n",
+       "6              0.020691             0.001906\n",
+       "7              0.020691             0.001948\n",
+       "8              0.020691             0.001882\n",
+       "9              0.029764             0.002020\n",
+       "10             0.029764             0.002089\n",
+       "11             0.029764             0.002094\n",
+       "12             0.042813             0.002321\n",
+       "13             0.042813             0.002347\n",
+       "14             0.042813             0.002367\n",
+       "15             0.061585             0.002350\n",
+       "16             0.061585             0.002423\n",
+       "17             0.061585             0.002328\n",
+       "18             0.088587             0.003427\n",
+       "19             0.088587             0.003372\n",
+       "20             0.088587             0.003334\n",
+       "21             0.127427             0.005977\n",
+       "22             0.127427             0.005895\n",
+       "23             0.127427             0.006184\n",
+       "24             0.183298             0.014290\n",
+       "25             0.183298             0.014007\n",
+       "26             0.183298             0.014514\n",
+       "27             0.263665             0.039195\n",
+       "28             0.263665             0.038163\n",
+       "29             0.263665             0.040298\n",
+       "30             0.379269             0.110125\n",
+       "31             0.379269             0.107740\n",
+       "32             0.379269             0.112896\n",
+       "33             0.545559             0.287883\n",
+       "34             0.545559             0.287488\n",
+       "35             0.545559             0.280638\n",
+       "36             0.784760             0.629371\n",
+       "37             0.784760             0.629222\n",
+       "38             0.784760             0.610708\n",
+       "39             1.128838             1.094227\n",
+       "40             1.128838             1.077963\n",
+       "41             1.128838             1.115127\n",
+       "42             1.623777             1.568231\n",
+       "43             1.623777             1.544967\n",
+       "44             1.623777             1.540069\n",
+       "45             2.335721             1.981019\n",
+       "46             2.335721             1.949427\n",
+       "47             2.335721             1.940893\n",
+       "48             3.359818             2.317968\n",
+       "49             3.359818             2.395118\n",
+       "50             3.359818             2.250463\n",
+       "51             4.832930             2.587113\n",
+       "52             4.832930             2.650764\n",
+       "53             4.832930             2.677703\n",
+       "54             6.951928             2.800365\n",
+       "55             6.951928             2.851770\n",
+       "56             6.951928             2.877590\n",
+       "57            10.000000             2.968849\n",
+       "58            10.000000             3.032485\n",
+       "59            10.000000             2.896894"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>known_concentration</th>\n",
+       "      <th>instrument_response</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.010000</td>\n",
+       "      <td>0.002069</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.010000</td>\n",
+       "      <td>0.002013</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.010000</td>\n",
+       "      <td>0.002117</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.014384</td>\n",
+       "      <td>0.001960</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.014384</td>\n",
+       "      <td>0.001988</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0.014384</td>\n",
+       "      <td>0.001944</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0.020691</td>\n",
+       "      <td>0.001906</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>0.020691</td>\n",
+       "      <td>0.001948</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>0.020691</td>\n",
+       "      <td>0.001882</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>0.029764</td>\n",
+       "      <td>0.002020</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>0.029764</td>\n",
+       "      <td>0.002089</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>0.029764</td>\n",
+       "      <td>0.002094</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>0.042813</td>\n",
+       "      <td>0.002321</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>0.042813</td>\n",
+       "      <td>0.002347</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>0.042813</td>\n",
+       "      <td>0.002367</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>0.061585</td>\n",
+       "      <td>0.002350</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>0.061585</td>\n",
+       "      <td>0.002423</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>0.061585</td>\n",
+       "      <td>0.002328</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>0.088587</td>\n",
+       "      <td>0.003427</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>0.088587</td>\n",
+       "      <td>0.003372</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>0.088587</td>\n",
+       "      <td>0.003334</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>0.127427</td>\n",
+       "      <td>0.005977</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>0.127427</td>\n",
+       "      <td>0.005895</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>0.127427</td>\n",
+       "      <td>0.006184</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>0.183298</td>\n",
+       "      <td>0.014290</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>0.183298</td>\n",
+       "      <td>0.014007</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>0.183298</td>\n",
+       "      <td>0.014514</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>0.263665</td>\n",
+       "      <td>0.039195</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>0.263665</td>\n",
+       "      <td>0.038163</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>0.263665</td>\n",
+       "      <td>0.040298</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
+       "      <td>0.379269</td>\n",
+       "      <td>0.110125</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31</th>\n",
+       "      <td>0.379269</td>\n",
+       "      <td>0.107740</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32</th>\n",
+       "      <td>0.379269</td>\n",
+       "      <td>0.112896</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>0.545559</td>\n",
+       "      <td>0.287883</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>34</th>\n",
+       "      <td>0.545559</td>\n",
+       "      <td>0.287488</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35</th>\n",
+       "      <td>0.545559</td>\n",
+       "      <td>0.280638</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36</th>\n",
+       "      <td>0.784760</td>\n",
+       "      <td>0.629371</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>37</th>\n",
+       "      <td>0.784760</td>\n",
+       "      <td>0.629222</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>0.784760</td>\n",
+       "      <td>0.610708</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39</th>\n",
+       "      <td>1.128838</td>\n",
+       "      <td>1.094227</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>40</th>\n",
+       "      <td>1.128838</td>\n",
+       "      <td>1.077963</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>41</th>\n",
+       "      <td>1.128838</td>\n",
+       "      <td>1.115127</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>42</th>\n",
+       "      <td>1.623777</td>\n",
+       "      <td>1.568231</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>43</th>\n",
+       "      <td>1.623777</td>\n",
+       "      <td>1.544967</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>44</th>\n",
+       "      <td>1.623777</td>\n",
+       "      <td>1.540069</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>45</th>\n",
+       "      <td>2.335721</td>\n",
+       "      <td>1.981019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>46</th>\n",
+       "      <td>2.335721</td>\n",
+       "      <td>1.949427</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47</th>\n",
+       "      <td>2.335721</td>\n",
+       "      <td>1.940893</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>48</th>\n",
+       "      <td>3.359818</td>\n",
+       "      <td>2.317968</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>3.359818</td>\n",
+       "      <td>2.395118</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50</th>\n",
+       "      <td>3.359818</td>\n",
+       "      <td>2.250463</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>51</th>\n",
+       "      <td>4.832930</td>\n",
+       "      <td>2.587113</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>52</th>\n",
+       "      <td>4.832930</td>\n",
+       "      <td>2.650764</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>53</th>\n",
+       "      <td>4.832930</td>\n",
+       "      <td>2.677703</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>54</th>\n",
+       "      <td>6.951928</td>\n",
+       "      <td>2.800365</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55</th>\n",
+       "      <td>6.951928</td>\n",
+       "      <td>2.851770</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>56</th>\n",
+       "      <td>6.951928</td>\n",
+       "      <td>2.877590</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>57</th>\n",
+       "      <td>10.000000</td>\n",
+       "      <td>2.968849</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>58</th>\n",
+       "      <td>10.000000</td>\n",
+       "      <td>3.032485</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>59</th>\n",
+       "      <td>10.000000</td>\n",
+       "      <td>2.896894</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 35
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T08:16:57.717329Z",
+     "start_time": "2024-11-20T08:16:57.513277Z"
+    }
+   },
+   "source": [
+    "df.plot.scatter(x=\"known_concentration\", y=\"instrument_response\", logx=True, logy=True)"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='known_concentration', ylabel='instrument_response'>"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkIAAAG1CAYAAAAV2Js8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuNSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/xnp5ZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA6XUlEQVR4nO3de3xU1b3H/e8AIZLbGJJwCQQSIKJBIRiSFOSqKGIVEGs5HFsioE+VCNbYWrEFseqx2mppZR48ghbpUcqRKipaiiAXBVrCJXgJhFuEyC0XICEJ5rqfP3yY45BkMkzmPp/365XXi1lrz96/ibuZb9dee22TYRiGAAAAglA7bxcAAADgLQQhAAAQtAhCAAAgaBGEAABA0CIIAQCAoEUQAgAAQYsgBAAAglYHbxfg6xobG3XixAlFRkbKZDJ5uxwAAOAAwzB0/vx5xcfHq127lsd9CEKtOHHihBISErxdBgAAcEJRUZF69uzZYj9BqBWRkZGSvvtFRkVFebkaAADgiIqKCiUkJFi/x1tCEGrFxcthUVFRBCEAAPxMa9NamCwNAACCFkEIAAAELYJQCywWi1JSUpSenu7tUgAAgJuYDMMwvF2EL6uoqJDZbFZ5eTlzhAAA8BOOfn8zIgQAAIIWQQgAAAQtghAAAAhaBCEAABC0CEIAACBoEYQAAEDQ4hEbAADAK46UVOromWolxoQrKTbcKzUQhAAAgEedq67VnBV52nKwxNo2MjlOL08dLHNYiEdr4dIYAADwqFlv7rYJQZK05WCJHnxzl8drIQgBAIBmbS4o1p82HNCnl4SWtjhSUqlth8ua7dt2uEyFpVUuO5YjuDQGAABsHC2r0iTLVp2trrO2RYeF6P3s4UqICWvTvv9d2HwIsvYfKfPofCFGhFrAQ1cBAMFq4iLbECRJZ6vrdMeiz9q875Lztfb7K2vafIzLQRBqQXZ2tvLz85Wbm+vtUgAAaJGrL19tLijWuQt1zfadu1DX5uPERXa03x8R2qb9Xy4ujQEA4IfcdflqY0Gx3f5P9hVrRHKc0/vPTIqx39/Hfr+rMSIEAIAfctflq87h9kdkOkfYH9FpTZ+4CA3r23zYGdY3xuPrCRGEAADwM+68fHX7wO6t9Mc7ve+LFt+TppGXjCqNTI7T4nvS2rzvy8WlMQAA/Iw7L1/1iYtQeu9o5R4926QvvXe0S0ZszGEhWj4zQ4WlVfq6rMqrK0szIgQAgBsdKanUxoJil66P4+7LV0uz0psdsVma5do7qZNiwzWmfxevhSCJESEAANzCnY+RuH1gd7308QE7/W27fOVLIzbuxogQAABu4M7HSFy8fNUcV12+knxjxMbdCEIAALiYJx4j4anLV4GOS2MAALiYJx4jEUyXr9yJIAQAgMuZ7PYaLjxSUiwBqC24NAYAgIvFm6+w298zupOHKkFrCEIAALhYYyv99Y2uHBNCWxCEAABwsd6d7T/rKzGGS1m+giAEAAhqK3cc089X7tHbO4tcts8+cREamRyn9ibbuULtTSaNTI5jTo8PMRmGwficHRUVFTKbzSovL1dUVJS3ywEAuMgX35zTnf/vNpvLVB3amfR+9g1K6WFu8/7Lq+s0e8UetyyoiNY5+v1NEGoFQQgAAlO/Jz5qdq5Oh3YmHfqv21x2HG5v9w5Hv7+5NNYCi8WilJQUpaezMBUABJqVO461OGG5vtFw6WWyYFid2Z8RhFqQnZ2t/Px85ebmersUAICLbW9lwcOth0s9VAm8jSAEAAg6Q5Ni7Pbf0DfWQ5XA2whCAICgMyWjlzq0a3715w7tTLp7SIKHK4K3EIQAAEHp/ewbmoShi3eNIXjwrDEAQFBK6WHWof+6TW/vLNLWw6W6oW8sI0FBiCAEAAhqdw9JIAAFMYIQAMCnHSmp1NEz1azDA7cgCAEAfNK56lrNWZHHysxwKyZLAwB80n1v7LQJQZK05WCJ7nuD9d3gOgQhAIDPOVJSqZ1Hzzbbl3v0rApLqzxcEQIVQQgA4HPWfH6ylf4THqoEgY4gBADwOWeqauz3V9Z6qBIEOoIQAMDnjOnfxW7/jdfY7wccRRACAPicUf276MpOzd8ZdmWnEI1IjvNwRQhUBCEAgE/64KHhir7kNvnosBB98NBwL1WEQMQ6QgAAn5QQE6Y982/RpwdLtPvYWV3fK5qRILgcQQgA4NNGJMcRgOA2XBoDAABBiyAEAACCFkEIAAAELYIQAAAIWgQhAAAQtLhrDADQZkdKKnX0TLUSY8KVFBvu7XIAhxGEAABOO1ddqzkr8rTlYIm1bWRynF6eOljmsOZXhgZ8CZfGAABO+3+W77QJQZK05WCJ7l++00sVAZcnKILQmjVr1L9/fyUnJ2vp0qXeLgcAAsKRkkrt+Ppss307vj6jwtIqD1cEXL6AD0L19fXKycnRJ598oj179uj3v/+9ysrKvF0WAPi9NZ+fsNv/YSv9gC8I+CC0Y8cODRgwQD169FBERITGjx+vdevWebssAPB7Z6pq7faXVtZ4qBLAeT4fhLZs2aI77rhD8fHxMplMWr16dZNtLBaLEhMTdcUVVygzM1M7duyw9p04cUI9evSwvu7Ro4eOHz/uidIBIKCN6d/Fbv9N13T1UCWA83w+CFVVVWnQoEGyWCzN9q9cuVI5OTl68skntXv3bg0aNEjjxo1TcXGxhysFgOAyqn8XmTs1f/OxuVMHHpQKv+DzQWj8+PF65plndOeddzbb/9JLL+n+++/X9OnTlZKSoldeeUVhYWF6/fXXJUnx8fE2I0DHjx9XfHx8i8erqalRRUWFzQ8AoHlrHhqh6Etuk48OC9Gah0Z4qSLg8vj1OkK1tbXatWuX5s6da21r166dxo4dq+3bt0uSMjIy9OWXX+r48eMym836xz/+oXnz5rW4z+eee05PPfWU22sHgECQEBOmPfNv0acHS7T72Fld3yuakSD4Fb8OQqWlpWpoaFDXrrbXobt27ar9+/dLkjp06KAXX3xRY8aMUWNjox577DHFxMS0uM+5c+cqJyfH+rqiokIJCQnu+QAAECBGJMcRgOCX/DoIOWrChAmaMGGCQ9uGhoYqNDTUzRUBAABf4PNzhOyJjY1V+/btdfr0aZv206dPq1u3bl6qCgAA+Au/DkIdO3ZUWlqaNmzYYG1rbGzUhg0bNHTo0Dbt22KxKCUlRenp6W0tEwAA+CifvzRWWVmpQ4cOWV8XFhYqLy9PnTt3Vq9evZSTk6OsrCwNGTJEGRkZWrhwoaqqqjR9+vQ2HTc7O1vZ2dmqqKiQ2Wxu68cAAAA+yOeD0M6dOzVmzBjr64sTmbOysrRs2TJNmTJFJSUlmj9/vk6dOqXU1FStXbu2yQRqAACAS5kMwzC8XYQvuzgiVF5erqioKG+XAwAAHODo97dfzxECAABoC4IQAAAIWgShFnDXGAAAgY85Qq1gjhAAAP6HOUIAAACtIAgBAICgRRACAABBiyAEAACCFkGoBdw1BgBA4OOusVZw1xiAQLC5oFh535zT9b2iNSI5ztvlAG7n6Pe3zz9rDADgvKNlVZpk2aqz1XXWtuiwEL2fPVwJMWFerAzwDVwaA4AANmHRZzYhSJLOVtfp9kWfeqkiwLcQhAAgQG0uKFb5hfpm+8ov1OvTgyUergjwPQQhAAhQGwuK7fZv2HfaQ5UAvosgBAABqnN4R7v9sRGhHqoE8F0EoRZw+zwAf3f7wHi7/T9spR8IBgShFmRnZys/P1+5ubneLgUAnNInLkIZiZ2b7ctI7Kyk2HAPVwT4HoIQAASwJdOGaOQl6waNTI7TkmlDvFQR4FtYRwgAApg5LETLZ2aosLRKX5dVKTEmnJEg4HsIQgAQBJJiCUBAc7g0BgAAghZBCAAABC2CEAAACFoEoRawjhAAAIHPZBiG4e0ifFlFRYXMZrPKy8sVFRXl7XIAAIADHP3+ZkQIAAAELYIQAAAIWgQhAAAQtAhCAAAgaBGEAABA0CIIAQCAoEUQAgAAQYsgBAAAghZBqAWsLA0AQOBjZelWsLI0AAD+h5WlAQAAWkEQAgAAQYsgBAAAghZBCAAABC2CEAAACFptCkK1tbUqKChQfX29q+oBAADwGKeCUHV1tWbOnKmwsDANGDBAx44dkyTNnj1bv/vd71xaIAAAgLs4FYTmzp2rvXv3atOmTbriiius7WPHjtXKlStdVhwAAIA7dXDmTatXr9bKlSv1gx/8QCaTydo+YMAAHT582GXFAQAAuJNTQaikpERdunRp0l5VVWUTjAAAjtlcUKy8b87p+l7RGpEc5+1ygKDhVBAaMmSIPvzwQ82ePVuSrOFn6dKlGjp0qOuqA4AAd7SsSpMsW3W2us7aFh0WovezhyshJsyLlQHBwakg9F//9V8aP3688vPzVV9frz/96U/Kz8/Xtm3btHnzZlfX6BUWi0UWi0UNDQ3eLgVAAJuw6DOVX7C98/ZsdZ1uX/Sp9j45zktVAcHDqcnSw4cPV15enurr63Xddddp3bp16tKli7Zv3660tDRX1+gV2dnZys/PV25urrdLARCgNhcUNwlBF5VfqNenB0s8XBEQfJwaEZKkvn37asmSJa6sBQCCysaCYrv9G/adZr4Q4GZOjQjt3r1bX3zxhfX1e++9p0mTJumJJ55QbW2ty4oDgEDWObyj3f7YiFAPVQIEL6eC0M9+9jMdOHBAknTkyBFNmTJFYWFhevvtt/XYY4+5tEAACFS3D4y32//DVvoBtJ1TQejAgQNKTU2VJL399tsaNWqU3nrrLS1btkx///vfXVkfAASsPnERykjs3GxfRmJnJcWGe7giIPg4FYQMw1BjY6Mkaf369brtttskSQkJCSotLXVddQAQ4JZMG6KRl8wDGpkcpyXThnipIiC4OL2O0DPPPKOxY8dq8+bNWrx4sSSpsLBQXbt2dWmBABDIzGEhWj4zQ4WlVfq6rEqJMeGMBAEe5FQQWrhwoe655x6tXr1av/71r9WvXz9J0qpVqzRs2DCXFggAwSAplgAEeIPJMAzDVTv79ttv1b59e4WEhLhql15XUVEhs9ms8vJyRUVFebscAADgAEe/v51eR0iSamtrVVxcbJ0vdFGvXr3aslsAAACPcCoIHThwQDNnztS2bdts2g3DkMlk4rEUAADALzgVhKZPn64OHTpozZo16t69O0+cBwAAfsmpIJSXl6ddu3bp6quvdnU9AAAAHuPUOkIpKSmsFwQAAPyeU0Ho+eef12OPPaZNmzaprKxMFRUVNj8AAAD+wKnb59u1+y4/XTo3KBAnS3P7PAAA/sett89v3LjR6cIAAAB8hVNBaNSoUa6uAwAAwOOcXlDx3Llzeu2117Rv3z5J0oABAzRjxgyZzWaXFedNFotFFosloC7zAQAAW07NEdq5c6fGjRunTp06KSMjQ5KUm5urCxcuaN26dbr++utdXqi3MEcIAAD/4+j3t1NBaMSIEerXr5+WLFmiDh2+G1Sqr6/XfffdpyNHjmjLli3OV+5jCEIAAPgftwahTp06ac+ePU0WVMzPz9eQIUNUXV19+RX7KIIQAAD+x9Hvb6fWEYqKitKxY8eatBcVFSkyMtKZXQIAAHicU0FoypQpmjlzplauXKmioiIVFRXpb3/7m+677z5NnTrV1TUCAAC4hVN3jf3hD3+QyWTStGnTVF9fL0kKCQnRgw8+qN/97ncuLRAAAMBdnJojdFF1dbUOHz4sSerbt6/CwsJcVpivYI4QAAD+x60rS18UFhamK6+80vpvAAAAf+LUHKH6+nrNmzdPZrNZiYmJSkxMlNls1m9+8xvV1dW5ukYAAAC3cGpEaPbs2XrnnXf0wgsvaOjQoZKk7du3a8GCBSorK9PixYtdWiQAAIA7ODVHyGw2629/+5vGjx9v0/7RRx9p6tSpKi8vd1mB3sYcIQAA/I9b1xEKDQ1VYmJik/akpCR17NjRmV0CAAB4nFNB6KGHHtLTTz+tmpoaa1tNTY2effZZPfTQQy4rDgAAwJ2cmiO0Z88ebdiwQT179tSgQYMkSXv37lVtba1uuukmTZ482brtO++845pKAQAAXMypIHTllVfqrrvusmlLSEhwSUEAAACe4lQQ+stf/uLqOgAAADzOqTlCFy5csHnC/NGjR7Vw4UKtW7fOZYUBAAC4m1NBaOLEiVq+fLkk6dy5c8rIyNCLL76oiRMnsoYQAADwG04Fod27d2vEiBGSpFWrVqlbt246evSoli9frj//+c8uLRAAAMBdnApC1dXVioyMlCStW7dOkydPVrt27fSDH/xAR48edWmBAAAA7uJUEOrXr59Wr16toqIi/fOf/9Qtt9wiSSouLmb1ZQAA4DecCkLz58/XL37xCyUmJiojI8P6vLF169Zp8ODBLi0QAHzBkZJKbSwoVmFplbdLAeBCTj1rTJJOnTqlkydPatCgQWrX7rs8tWPHDkVFRenqq692aZHexLPGgOB2rrpWc1bkacvBEmvbyOQ4vTx1sMxhIV6sDIA9bn3WmCR169ZNkZGR+vjjj3XhwgVJUnp6ekCFIACY9eZumxAkSVsOlujBN3d5qSIAruRUECorK9NNN92kq666SrfddptOnjwpSZo5c6YeffRRlxYIAN5ypKRS2w6XNdu37XAZl8mAAOBUEHrkkUcUEhKiY8eOKSwszNo+ZcoUrV271mXFucqdd96p6Oho/ehHP/J2KQD8yL8Lmw9B1v4j9vsB+D6ngtC6dev0/PPPq2fPnjbtycnJPnn7/MMPP2xdABIAHFVyvtZ+f2WNhyoB4C5OBaGqqiqbkaCLzpw5o9DQ0DYX5WqjR4+2rnsEAI6Ki+xovz/C9/7eAbg8TgWhESNG2IywmEwmNTY26oUXXtCYMWMua19btmzRHXfcofj4eJlMJq1evbrJNhaLRYmJibriiiuUmZmpHTt2OFM2AFyWzKQY+/197PcD8H1OPX3+hRde0E033aSdO3eqtrZWjz32mL766iudOXNGW7duvax9VVVVadCgQZoxY4YmT57cpH/lypXKycnRK6+8oszMTC1cuFDjxo1TQUGBunTpIklKTU1VfX19k/euW7dO8fHxl1VPTU2Namr+b7i7oqList4PIHD0iYvQsL4xzU6YHtY3Rkmx4V6oCoArOb2OUHl5uRYtWqS9e/eqsrJS119/vbKzs9W9e3fnizGZ9O6772rSpEnWtszMTKWnp2vRokWSpMbGRiUkJGj27Nl6/PHHHd73pk2btGjRIq1atcrudgsWLNBTTz3VpJ11hIDgVF5dp9kr9rCOEOBnHF1H6LJHhOrq6nTrrbfqlVde0a9//es2Fdma2tpa7dq1S3PnzrW2tWvXTmPHjtX27dvdcsy5c+cqJyfH+rqiokIJCQluORYA32cOC9HymRkqLK3S12VVSowJZyQICCCXHYRCQkL0+eefu6OWJkpLS9XQ0KCuXbvatHft2lX79+93eD9jx47V3r17VVVVpZ49e+rtt9+2PhbkUqGhoT454RuAdyXFEoCAQOTUZOmf/OQneu2111xdi9usX79eJSUlqq6u1jfffNNiCAIAAMHFqcnS9fX1ev3117V+/XqlpaUpPNz2/yW99NJLLikuNjZW7du31+nTp23aT58+rW7durnkGAAAIHg5FYS+/PJLXX/99ZKkAwcO2PSZTKa2V/X/69ixo9LS0rRhwwbrBOrGxkZt2LBBDz30kMuO0xyLxSKLxaKGhga3HgcAAHiPU0Fo48aNDm33zTffKD4+3vp0+uZUVlbq0KFD1teFhYXKy8tT586d1atXL+Xk5CgrK0tDhgxRRkaGFi5cqKqqKk2fPt2Z0h2WnZ2t7Oxs66xzAAAQeJwKQo5KSUlRXl6e+vTp0+I2O3futFmE8eIdW1lZWVq2bJmmTJmikpISzZ8/X6dOnVJqaqrWrl3bZAI1AADA5XJ6HSFHREZGau/evXaDkK9zdB0CAADgOxz9/nbqrjEAAIBAQBACAABBiyDUAovFopSUFKWnp3u7FAAA4CZuDUKuvJXe07Kzs5Wfn6/c3FxvlwIAANzErUHIjfOwAQAA2sypIDRjxgydP3++SXtVVZVmzJhhfZ2fn6/evXs7Xx0AAIAbOXX7fPv27XXy5El16dLFpr20tFTdunVTfX29ywr0Nm6fBwDA/zj6/X1ZCypWVFTIMAwZhqHz58/riiuusPY1NDToo48+ahKOAAAAfNVlBaErr7xSJpNJJpNJV111VZN+k8mkp556ymXFeRPPGgMAIPBd1qWxzZs3yzAM3Xjjjfr73/+uzp07W/s6duyo3r17Kz4+3i2FeguXxgAA8D9uuTQ2atQoSd89GDUhIcHuw1QBAAB8nVMPXe3du7fOnTunHTt2qLi4WI2NjTb906ZNc0lxAAAA7uRUEPrggw90zz33qLKyUlFRUTYLJ5pMJoIQAADwC05d23r00Uc1Y8YMVVZW6ty5czp79qz158yZM66uEQAAwC2cCkLHjx/XnDlzFBYW5up6AAAAPMapIDRu3Djt3LnT1bX4FB66CgBA4HNqZenXXntNv/3tbzV9+nRdd911CgkJsemfMGGCywr0Nm6fBwDA/zj6/e1UELJ327zJZAqoRQgJQgAA+B+3rCN00aW3ywMAAPijNq+I+O2337qiDgAAAI9zKgg1NDTo6aefVo8ePRQREaEjR45IkubNm6fXXnvNpQUCAAC4i1NB6Nlnn9WyZcv0wgsvqGPHjtb2a6+9VkuXLnVZcQAAAO7kVBBavny5Xn31Vd1zzz1q3769tX3QoEHav3+/y4oDAABwJ6cXVOzXr1+T9sbGRtXV1bW5KF/AOkIAAAQ+p4JQSkqKPv300ybtq1at0uDBg9tclC/Izs5Wfn6+cnNzvV0KAABwE6dun58/f76ysrJ0/PhxNTY26p133lFBQYGWL1+uNWvWuLpGAAAAt3BqRGjixIn64IMPtH79eoWHh2v+/Pnat2+fPvjgA918882urhEAAMAtnFpZOpiwsjQAAP7HrStLf19lZWWTlaYJDAAAwB84dWmssLBQP/zhDxUeHi6z2azo6GhFR0fryiuvVHR0tKtrBACHHCmp1MaCYhWWVnm7FAB+wqkRoZ/85CcyDEOvv/66unbtKpPJ5Oq6AMBh56prNWdFnrYcLLG2jUyO08tTB8scFuLFygD4OqfmCEVERGjXrl3q37+/O2ryKcwRAnzffy75l7YdLmvSPqxvjN66/wdeqAiAtzn6/e3UpbH09HQVFRU5XRwAuMqRkspmQ5AkbTtcxmUyAHY5dWls6dKleuCBB3T8+HFde+21CgmxHXoeOHCgS4rzJovFIovFooaGBm+XAsCOfxc2H4Ks/UfKlBQb7qFqAPgbp4JQSUmJDh8+rOnTp1vbTCaTDMOQyWQKiPCQnZ2t7Oxs69AaAN9Ucr7Wfn9ljYcqAeCPnApCM2bM0ODBg7VixQomSwPwqrjIjvb7I0I9VAkAf+RUEDp69Kjef//9Zh+8CgCelJkUY7+/j/1+AMHNqcnSN954o/bu3evqWgDgsvWJi9Cwvs2HnWF9Y5gfBMAup0aE7rjjDj3yyCP64osvdN111zWZLD1hwgSXFAcAjlh8T5pmr9jT7DpCAGCPU+sItWvX8kBSoEyWvoh1hAD/UVhapa/LqpQYE85IEBDk3PqssUufLQYAviAplgAE4PI4NUcIAAAgEDg1IvTb3/7Wbv/8+fOdKgYAAMCTnApC7777rs3ruro6FRYWqkOHDurbty9BCAAA+AWngtCePXuatFVUVOjee+/VnXfe2eaiAAAAPMFlc4SioqL01FNPad68ea7aJQAAgFu5dLJ0eXm5ysvLXblLr7FYLEpJSVF6erq3SwEAAG7i1DpCf/7zn21eG4ahkydP6q9//atGjRqlt956y2UFehvrCAEA4H/cuo7QH//4R5vX7dq1U1xcnLKysjR37lxndgkAAOBxTgWhwsJCV9cBAADgcZc9R6iurk4dOnTQl19+6Y56AAAAPOayg1BISIh69eoVUM8TAwAAwcmpu8Z+/etf64knntCZM2dcXQ8AAIDHODVHaNGiRTp06JDi4+PVu3dvhYfbPuRw9+7dLikOAADAnZwKQhMnTpTJZHJ1LQAAAB7l1DpCwYR1hAAA8D+Ofn87NUeoT58+Kisra9J+7tw59enTx5ldAgAAeJxTQejrr79u9q6xmpoaffPNN20uCgAAwBMua47Q+++/b/33P//5T5nNZuvrhoYGbdiwQUlJSa6rDgAAwI0uKwhNmjRJkmQymZSVlWXTFxISosTERL344osuKw4AAMCdLisINTY2SpKSkpKUm5ur2NhYtxQFAADgCS571ti5c+d05ZVXtrUeAAAAj3FqsvTzzz+vlStXWl/ffffd6ty5s3r06KG9e/e6rDgAAAB3cioIvfLKK0pISJAkffzxx1q/fr3Wrl2r8ePH65e//KVLCwQAAHAXpy6NnTp1yhqE1qxZox//+Me65ZZblJiYqMzMTJcWCAAA4C5OjQhFR0erqKhIkrR27VqNHTtWkmQYRsA8ld5isSglJUXp6eneLgUAALiJU0Fo8uTJ+s///E/dfPPNKisr0/jx4yVJe/bsUb9+/VxaoLdkZ2crPz9fubm53i4FAAC4iVOXxv74xz8qMTFRRUVFeuGFFxQRESFJOnnypGbNmuXSAgEAANyFh662goeuAgDgfxz9/nZqREiSDh48qI0bN6q4uNi60OJF8+fPd3a3AAAAHuNUEFqyZIkefPBBxcbGqlu3bjKZTNY+k8lEEAIAAH7BqSD0zDPP6Nlnn9WvfvUrV9cDAADgMU7dNXb27Fndfffdrq4FAADAo5wKQnfffbfWrVvn6loAAAA8yqlLY/369dO8efP0r3/9S9ddd51CQkJs+ufMmeOS4gAAANzJqdvnk5KSWt6hyaQjR460qShfwu3zgOscKanU0TPVSowJV1JsuLfLARDA3Hr7fGFhodOFAQg+56prNWdFnrYcLLG2jUyO08tTB8scFmLnnQDgXg4HoZycHD399NMKDw9XTk5Oi9uZTCa9+OKLLikOQGCY9eZubTtcZtO25WCJHnxzl966/wdeqgoALiMI7dmzR3V1ddZ/t+T7awoBwJGSyiYh6KJth8tUWFrFZTIAXuNwENq4cWOz/wYAe/5d2HwIsvYfKSMIAfAap26fBwBHlZyvtd9fWeOhSgCgKYIQALeKi+xovz8i1EOVAEBTBCEAbpWZFGO/v4/9fgBwJ4IQALfqExehYX2bDzvD+sYwPwiAVxGEALjd4nvSNDI5zqZtZHKcFt+T5qWKAOA7Ti2oCACXwxwWouUzM1RYWqWvy6pYWRqAzyAIAfCYpFgCEADfwqUxAAAQtAhCAAAgaBGEAABA0CIIAQCAoBXwQaioqEijR49WSkqKBg4cqLffftvbJQEAAB8R8HeNdejQQQsXLlRqaqpOnTqltLQ03XbbbQoP584VAACCXcAHoe7du6t79+6SpG7duik2NlZnzpwhCAEAAO9fGtuyZYvuuOMOxcfHy2QyafXq1U22sVgsSkxM1BVXXKHMzEzt2LHDqWPt2rVLDQ0NSkhIaGPVAAAgEHh9RKiqqkqDBg3SjBkzNHny5Cb9K1euVE5Ojl555RVlZmZq4cKFGjdunAoKCtSlSxdJUmpqqurr65u8d926dYqPj5cknTlzRtOmTdOSJUvs1lNTU6Oamhrr64qKirZ8PAAA4MNMhmEY3i7iIpPJpHfffVeTJk2ytmVmZio9PV2LFi2SJDU2NiohIUGzZ8/W448/7tB+a2pqdPPNN+v+++/XT3/6U7vbLliwQE899VST9vLyckVFRTn+YQAAgNdUVFTIbDa3+v3t9Utj9tTW1mrXrl0aO3asta1du3YaO3astm/f7tA+DMPQvffeqxtvvLHVECRJc+fOVXl5ufWnqKjI6foBAIBv8+kgVFpaqoaGBnXt2tWmvWvXrjp16pRD+9i6datWrlyp1atXKzU1Vampqfriiy9a3D40NFRRUVE2PwAAIDB5fY6Quw0fPlyNjY3eLgMAAPggnx4Rio2NVfv27XX69Gmb9tOnT6tbt25eqgoAAAQKnw5CHTt2VFpamjZs2GBta2xs1IYNGzR06FC3HttisSglJUXp6eluPQ4AAPAer18aq6ys1KFDh6yvCwsLlZeXp86dO6tXr17KyclRVlaWhgwZooyMDC1cuFBVVVWaPn26W+vKzs5Wdna2ddY5AAAIPF4PQjt37tSYMWOsr3NyciRJWVlZWrZsmaZMmaKSkhLNnz9fp06dUmpqqtauXdtkAjUAAMDl8ql1hHyRo+sQAAAA3xEQ6wgBAAC4E0GoBUyWBgAg8HFprBVcGgMAwP9waQwAAKAVBCEAABC0CEIAACBoEYQAAEDQIgi1gLvGAAAIfNw11gruGgMAwP84+v3t9UdsAPAdR0oqdfRMtRJjwpUUG+7tcgDA7QhCAHSuulZzVuRpy8ESa9vI5Di9PHWwzGEhXqwMANyLOUIANGdFnrYeKrVp23qoVLNX7PFSRQDgGQQhIMgdKanUloMlarhkumCDYWjLwRIVllZ5qTIAcD+CEBDkjp6pttv/dRlBCEDgIgi1gNvnESyKy7+12196vsZDlQCA5xGEWpCdna38/Hzl5uZ6uxTArU6dtx+ETpRf8FAlAOB5BCEgyKX2vNJu//W9oj1TCAB4AUEICHKj+ndRdAu3yEeHhWhEcpyHKwIAzyEIAdD72cObhKHosBC9nz3cSxUBgGewoCIAJcSEac/8W/TpwRLtPnZW1/eKZiQIQFAgCAGwGpEcRwACEFS4NAYAAIIWQQgAAAQtglALWFARAIDAZzKMSx4wBBsVFRUym80qLy9XVFSUt8sBAAAOcPT7mxEhAAAQtAhCAAAgaBGEAABA0CIIAQCAoEUQAgAAQYsgBAAAghZBCAAABC2CEAAACFoEoRawsjQAAIGPlaVbwcrSAAD4H1aWBgAAaEUHbxcA4PIcKanU0TPVSowJV1JsuLfLAQC/RhAC/MS56lrNWZGnLQdLrG0jk+P08tTBMoeFeLEyAPBfXBoD/MR9b+y0CUGStOVgie57I9dLFQGA/yMIAX7gSEmldh4922xf7tGzKiyt8nBFABAYCEKAH1jz+clW+k94qBIACCwEIcAPnKmqsd9fWeuhSgAgsBCEAD8wpn8Xu/03XmO/HwDQPIIQ4AdG9e+iKzs1f2fYlZ1CNCI5zsMVAUBgIAgBfuKDh4Yr+pLb5KPDQvTBQ8O9VBEA+D/WEQL8REJMmPbMv0WfHizR7mNndX2vaEaCAKCNCEItsFgsslgsamho8HYpgI0RyXEEIABwER662goeugoAgP/hoasAAACtIAgBAICgRRACAABBiyAEAACCFneNAS52pKRSR89UKzEmXEmx4d4uBwBgB0EIQWdzQbHyvjnn8nV4zlXXas6KPG05WGJtG5kcp5enDpY5rPlVoQEA3kUQQtA4WlalSZatOltdZ22LDgvR+9nDlRAT1ub93798p3K/PmvTtuVgie5fnqv/fWBYm/cPAHA95gghaExcZBuCJOlsdZ3uWPRZm/d9pKSySQi6aMfXZ1VYWtXmYwAAXI8ghKCwuaBY5y7UNdt37kKdPv3e5SxnrPn8hN3+D1vpBwB4B0EIQWFjQbHd/k/22e9vzZmq5kPWRaWVtW3aPwDAPQhCXnKkpFIbC4q5ZNKMzQXF+tOGA20epfm+zuGh9vsjOrZp/2P62590fdM1Xdq0fwCAezBZ2sO4s6hl7pzMfPvA7nrp4wN2+uPbtP9R/bvI3ClE5c1cfjN3CuEhqQDgoxgR8rBZb+62CUHSd3cWPfjmLi9V5DsuDUHSd5OZJ1jaPpm5T1yE0ntHN9uX3jvaJev9rHlouKIvCbPRYSFa89DwNu8bAOAejAh50JGSSm07XNZs37bDZSosrXLZAnzuWivHXTYXFDcJQRedrf5uMnNbP8fSrHTNXrGn2dE4V0iICdOe+bfo04Ml2n3srN/87gEgmBGEPOjfhc2HIGv/kbI2ByF3r5VzkatXT8775pzd/t3HzrY5VJjDQrR8ZoYKS6v0dVmV21Z+HpEcRwACAD9BEPKgkvP27xwqqaxp8zEmLPpM5RfqbdrOVtfp9kWfau+T49q8f3fNceoWeYXd/nhzJ6f3famkWB59AQD4DnOEWmCxWJSSkqL09HSX7TMu0v6dSXER9u9sas3mguImIeii8gv1LrkL6/7lO5ud43T/8tw27beL2X4Qio1s2+8GAIDmEIRakJ2drfz8fOXmtu0L/vsyk2Ls9/ex39+a1tbK2bDvdJv2787Vk3t3tn/ZLjGGERwAgOsRhDyoT1yEhvVtPuwM6xvT5ss1ncPtjzjFtnHEyZ2rJ/eJi9DI5Di1N5ls2tubTBqZHMelLACAWxCEPGzxPWkaeclE2pHJcVp8T1qb993aWjg/bONaOe5ePfnlqYN1Q79Ym7Yb+sW67K4uAAAuxWRpD3PnnUt94iKUkdhZO74+06QvI7Fzm48zpn+clm37usX+tq6e7Km7ugAAuIgRIS9Jig3XmP5dXP5Fv2TakGZHnJZMG9LmfV9cPbk5rlw92V2/GwAALmUyDMPwdhG+rKKiQmazWeXl5YqKivJ2OQ5z16hKUVm1Jlg+c/s6RQAAtIWj398EoVb4axByN1ZPBgD4Mke/v5kjBKewejIAIBAwRwgAAAQtghAAAAhaBCEAABC0CEIAACBoEYQAAEDQIggBAICgRRACAABBiyAEAACCFkEIAAAELYIQAAAIWjxioxUXH8VWUVHh5UoAAICjLn5vt/ZIVYJQK86fPy9JSkhI8HIlAADgcp0/f15ms7nFfp4+34rGxkadOHFCkZGRMplMzW6Tnp6u3Nzcy+qrqKhQQkKCioqK/Oqp9vY+qy8fy9l9Xe77HN3eke1a26a5fn89ryTPnVu+cF5d7nu9fV5J/ntucV65Zntnz5vW+t15XhmGofPnzys+Pl7t2rU8E4gRoVa0a9dOPXv2tLtN+/btW/wPaK9PkqKiovzqj0prn8dXj+Xsvi73fY5u78h2rW1jr9/fzivJc+eWL5xXl/teXzmvJP87tzivXLN9W88bb51X9kaCLmKytAtkZ2c71eePPPl5XHksZ/d1ue9zdHtHtmttG84t7x+nLfu6nPdyXjmP88o127f1vPHl84pLY15SUVEhs9ms8vJyv/p/V/BtnFdwF84tuIMvnFeMCHlJaGionnzySYWGhnq7FAQQziu4C+cW3MEXzitGhAAAQNBiRAgAAAQtghAAAAhaBCEAABC0CEIAACBoEYQAAEDQIgj5gaKiIo0ePVopKSkaOHCg3n77bW+XhABx5513Kjo6Wj/60Y+8XQr82Jo1a9S/f38lJydr6dKl3i4HAcQTf6O4fd4PnDx5UqdPn1ZqaqpOnTqltLQ0HThwQOHh4d4uDX5u06ZNOn/+vN544w2tWrXK2+XAD9XX1yslJUUbN26U2WxWWlqatm3bppiYGG+XhgDgib9RjAj5ge7duys1NVWS1K1bN8XGxurMmTPeLQoBYfTo0YqMjPR2GfBjO3bs0IABA9SjRw9FRERo/PjxWrdunbfLQoDwxN8ogpALbNmyRXfccYfi4+NlMpm0evXqJttYLBYlJibqiiuuUGZmpnbs2OHUsXbt2qWGhgYlJCS0sWr4Ok+eVwhebT3PTpw4oR49elhf9+jRQ8ePH/dE6fBx/vI3jCDkAlVVVRo0aJAsFkuz/StXrlROTo6efPJJ7d69W4MGDdK4ceNUXFxs3SY1NVXXXnttk58TJ05Ytzlz5oymTZumV1991e2fCd7nqfMKwc0V5xnQHL85twy4lCTj3XfftWnLyMgwsrOzra8bGhqM+Ph447nnnnN4v99++60xYsQIY/ny5a4qFX7EXeeVYRjGxo0bjbvuussVZcLPOXOebd261Zg0aZK1/+GHHzbefPNNj9QL/9GWv2Hu/hvFiJCb1dbWateuXRo7dqy1rV27dho7dqy2b9/u0D4Mw9C9996rG2+8UT/96U/dVSr8iCvOK6A1jpxnGRkZ+vLLL3X8+HFVVlbqH//4h8aNG+etkuEnfOlvGEHIzUpLS9XQ0KCuXbvatHft2lWnTp1yaB9bt27VypUrtXr1aqWmpio1NVVffPGFO8qFn3DFeSVJY8eO1d13362PPvpIPXv2JETBhiPnWYcOHfTiiy9qzJgxSk1N1aOPPsodY2iVo3/DPPE3qoPL9wiXGz58uBobG71dBgLQ+vXrvV0CAsCECRM0YcIEb5eBAOSJv1GMCLlZbGys2rdvr9OnT9u0nz59Wt26dfNSVfB3nFfwBM4zuIsvnVsEITfr2LGj0tLStGHDBmtbY2OjNmzYoKFDh3qxMvgzzit4AucZ3MWXzi0ujblAZWWlDh06ZH1dWFiovLw8de7cWb169VJOTo6ysrI0ZMgQZWRkaOHChaqqqtL06dO9WDV8HecVPIHzDO7iN+eW2+5HCyIbN240JDX5ycrKsm7z8ssvG7169TI6duxoZGRkGP/617+8VzD8AucVPIHzDO7iL+cWzxoDAABBizlCAAAgaBGEAABA0CIIAQCAoEUQAgAAQYsgBAAAghZBCAAABC2CEAAACFoEIQAAELQIQgAAIGgRhIAANXr0aP385z/3dhnwsK+//lomk0l5eXneLgXwCwQhAPCQBQsWKDU11WX7u/feezVp0iSbtoSEBJ08eVLXXnuty44DBDKCEAD4mLq6Oqff2759e3Xr1k0dOnRwYUVA4CIIAUHiww8/lNls1ptvvmkdSfjDH/6g7t27KyYmRtnZ2TZfwGfPntW0adMUHR2tsLAwjR8/XgcPHpQkGYahuLg4rVq1yrp9amqqunfvbn392WefKTQ0VNXV1ZIkk8mkpUuX6s4771RYWJiSk5P1/vvvO1z/V199pdtvv11RUVGKjIzUiBEjdPjwYUlSY2Ojfvvb36pnz54KDQ1Vamqq1q5da33vxctF77zzjsaMGaOwsDANGjRI27dvtznG1q1bNXr0aIWFhSk6Olrjxo3T2bNnrcd47rnnlJSUpE6dOmnQoEE2n3/Tpk0ymUzasGGDhgwZorCwMA0bNkwFBQWSpGXLlumpp57S3r17ZTKZZDKZtGzZMuvvZvHixZowYYLCw8P17LPPqqGhQTNnzrQer3///vrTn/5kPd6CBQv0xhtv6L333rPub9OmTc1eGtu8ebMyMjIUGhqq7t276/HHH1d9fb21f/To0ZozZ44ee+wxde7cWd26ddOCBQsc/m8D+DWPP+8egEeMGjXKePjhhw3DMIw333zTiIyMND744APDMAwjKyvLiIqKMh544AFj3759xgcffGCEhYUZr776qvX9EyZMMK655hpjy5YtRl5enjFu3DijX79+Rm1trWEYhjF58mQjOzvbMAzDOHPmjNGxY0fDbDYb+/btMwzDMJ555hnjhhtusO5PktGzZ0/jrbfeMg4ePGjMmTPHiIiIMMrKylr9LN98843RuXNnY/LkyUZubq5RUFBgvP7668b+/fsNwzCMl156yYiKijJWrFhh7N+/33jssceMkJAQ48CBA4ZhGEZhYaEhybj66quNNWvWGAUFBcaPfvQjo3fv3kZdXZ1hGIaxZ88eIzQ01HjwwQeNvLw848svvzRefvllo6SkxPp5rr76amPt2rXG4cOHjb/85S9GaGiosWnTJsMwDGPjxo2GJCMzM9PYtGmT8dVXXxkjRowwhg0bZhiGYVRXVxuPPvqoMWDAAOPkyZPGyZMnjerqauvvpkuXLsbrr79uHD582Dh69KhRW1trzJ8/38jNzTWOHDli/M///I8RFhZmrFy50jAMwzh//rzx4x//2Lj11lut+6upqbF+1j179lh/d2FhYcasWbOMffv2Ge+++64RGxtrPPnkkzbnSlRUlLFgwQLjwIEDxhtvvGGYTCZj3bp1rf63AfwdQQgIUBeD0KJFiwyz2Wz9wjaM74JQ7969jfr6emvb3XffbUyZMsUwDMM4cOCAIcnYunWrtb+0tNTo1KmT8b//+7+GYRjGn//8Z2PAgAGGYRjG6tWrjczMTGPixInG4sWLDcMwjLFjxxpPPPGE9f2SjN/85jfW15WVlYYk4x//+Eern2Xu3LlGUlKSNYRdKj4+3nj22Wdt2tLT041Zs2YZhvF/QWjp0qXW/q+++sqQZA1uU6dOtQlu3/ftt98aYWFhxrZt22zaZ86caUydOtUwjP8LQuvXr7f2f/jhh4Yk48KFC4ZhGMaTTz5pDBo0qMn+JRk///nP7f0KDMMwjOzsbOOuu+6yvs7KyjImTpxos82lQeiJJ54w+vfvbzQ2Nlq3sVgsRkREhNHQ0GAYxnfnyvDhw232k56ebvzqV79qtSbA33FpDAhgq1at0iOPPKKPP/5Yo0aNsukbMGCA2rdvb33dvXt3FRcXS5L27dunDh06KDMz09ofExOj/v37a9++fZKkUaNGKT8/XyUlJdq8ebNGjx6t0aNHa9OmTaqrq9O2bds0evRom2MOHDjQ+u/w8HBFRUVZj2lPXl6eRowYoZCQkCZ9FRUVOnHihG644Qab9htuuMFaa3PHv3gZ7+Lx8/LydNNNNzV7/EOHDqm6ulo333yzIiIirD/Lly+3Xp5z5Bj2DBkypEmbxWJRWlqa4uLiFBERoVdffVXHjh1rdV/ft2/fPg0dOlQmk8nadsMNN6iyslLffPNNs3VfrN2RugF/x2w6IIANHjxYu3fv1uuvv64hQ4bYfBleGipMJpMaGxsd3vd1112nzp07a/Pmzdq8ebOeffZZdevWTc8//7xyc3NVV1enYcOG2bzH2WN26tTJ4brs+f7xL/4uLh7f3jEqKyslfTfPqkePHjZ9oaGhDh/DnvDwcJvXf/vb3/SLX/xCL774ooYOHarIyEj9/ve/17///e9W9+WMtp4PgL9iRAgIYH379tXGjRv13nvvafbs2Q6/75prrlF9fb3Nl25ZWZkKCgqUkpIi6bsvyhEjRui9997TV199peHDh2vgwIGqqanRf//3f2vIkCFNvtydNXDgQH366afN3k0VFRWl+Ph4bd261aZ969at1lodPcaGDRua7UtJSVFoaKiOHTumfv362fwkJCQ4fIyOHTuqoaHBoW23bt2qYcOGadasWRo8eLD69evXZPTJkf1dc8012r59uwzDsNl3ZGSkevbs6XDtQKAiCAEB7qqrrtLGjRv197//3eEFFpOTkzVx4kTdf//9+uyzz7R371795Cc/UY8ePTRx4kTrdqNHj9aKFSuUmpqqiIgItWvXTiNHjtSbb77Z5FJcWzz00EOqqKjQf/zHf2jnzp06ePCg/vrXv1rvyPrlL3+p559/XitXrlRBQYEef/xx5eXl6eGHH3b4GHPnzlVubq5mzZqlzz//XPv379fixYtVWlqqyMhI/eIXv9AjjzyiN954Q4cPH9bu3bv18ssv64033nD4GImJiSosLFReXp5KS0tVU1PT4rbJycnauXOn/vnPf+rAgQOaN2+ecnNzm+zv888/V0FBgUpLS5sNirNmzVJRUZFmz56t/fv367333tOTTz6pnJwctWvHVwDA/wqAINC/f3998sknWrFihR599FGH3vOXv/xFaWlpuv322zV06FAZhqGPPvrI5hLKqFGj1NDQYDMXaPTo0U3a2iomJkaffPKJKisrNWrUKKWlpWnJkiXWWubMmaOcnBw9+uijuu6667R27Vq9//77Sk5OdvgYV111ldatW6e9e/cqIyNDQ4cO1XvvvWddj+fpp5/WvHnz9Nxzz+maa67Rrbfeqg8//FBJSUkOH+Ouu+7SrbfeqjFjxiguLk4rVqxocduf/exnmjx5sqZMmaLMzEyVlZVp1qxZNtvcf//96t+/v4YMGaK4uLgmo2KS1KNHD3300UfasWOHBg0apAceeEAzZ87Ub37zG4frBgKZyfj+eCkAAEAQYUQIAAAELYIQAK974IEHbG5L//7PAw884O3yAAQwLo0B8Lri4mJVVFQ02xcVFaUuXbp4uCIAwYIgBAAAghaXxgAAQNAiCAEAgKBFEAIAAEGLIAQAAIIWQQgAAAQtghAAAAhaBCEAABC0/j/SijUP9qfeMQAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 36
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we'd like to fit a standard curve to these data to estimate the concentration of an unknown sample given its observed response signal. Per the plot, we clearly need a non-linear model to fit the data.\n",
+    "\n",
+    "To do this, we'll use the `bio-curve-fit` package to fit a four-parameter and five-parameter logistic model to the data. Both models are used to fit dose-response data and are defined as:\n",
+    "\n",
+    "$$f(x) = \\frac{A-D}{1+\\left(\\frac{x}{C}\\right)^B}+D$$\n",
+    "\n",
+    "                                                \n",
+    "and\n",
+    "\n",
+    "$$f(x) = D + \\frac{A - D}{\\left(1 + \\left(\\frac{x}{C}\\right)^B\\right)^S}$$\n",
+    "\n",
+    "respectively.\n",
+    "\n",
+    "`bio-curve-fit` will find the values for the parameters $A$, $B$, $C$, $D$, and $S$ that best fit the example data above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T08:16:58.710830Z",
+     "start_time": "2024-11-20T08:16:58.704222Z"
+    }
+   },
+   "source": [
+    "# instantiate a 4PL model object\n",
+    "four_pl_model = FourPLLogistic()\n",
+    "\n",
+    "x = df[\"known_concentration\"]\n",
+    "y = df[\"instrument_response\"]\n",
+    "\n",
+    "\n",
+    "# fit the model using the data\n",
+    "four_pl_model.fit(x, y, weight_func=lambda x:x)\n",
+    "four_pl_model"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "FourPLLogistic(A=0.001949464936626857, B=2.845595637975574,\n",
+       "               C=1.1722476686290517, D=2.5040078221095095)"
+      ],
+      "text/html": [
+       "<style>#sk-container-id-11 {color: black;}#sk-container-id-11 pre{padding: 0;}#sk-container-id-11 div.sk-toggleable {background-color: white;}#sk-container-id-11 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-11 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-11 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-11 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-11 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-11 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-11 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-11 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-11 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-11 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-11 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-11 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-11 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-11 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-11 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-11 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-11 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-11 div.sk-item {position: relative;z-index: 1;}#sk-container-id-11 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-11 div.sk-item::before, #sk-container-id-11 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-11 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-11 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-11 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-11 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-11 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-11 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-11 div.sk-label-container {text-align: center;}#sk-container-id-11 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-11 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-11\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>FourPLLogistic(A=0.001949464936626857, B=2.845595637975574,\n",
+       "               C=1.1722476686290517, D=2.5040078221095095)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-11\" type=\"checkbox\" checked><label for=\"sk-estimator-id-11\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">FourPLLogistic</label><div class=\"sk-toggleable__content\"><pre>FourPLLogistic(A=0.001949464936626857, B=2.845595637975574,\n",
+       "               C=1.1722476686290517, D=2.5040078221095095)</pre></div></div></div></div></div>"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 37
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T08:16:58.920322Z",
+     "start_time": "2024-11-20T08:16:58.908023Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# instantiate a 5PL model object\n",
+    "five_pl_model = FivePLLogistic()\n",
+    "\n",
+    "x = df[\"known_concentration\"]\n",
+    "y = df[\"instrument_response\"]\n",
+    "\n",
+    "\n",
+    "# fit the model using the data\n",
+    "five_pl_model.fit(x, y, weight_func=lambda x:x)\n",
+    "five_pl_model"
+   ],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nickflores_ganymede/dev/bio-curve-fit/bio_curve_fit/logistic.py:540: RuntimeWarning: invalid value encountered in power\n",
+      "  z = (np.sign(x / C) * np.abs(x / C)) ** B\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "FivePLLogistic(A=0.002006901257671911, B=3.087036820144977,\n",
+       "               C=0.6903113152785875, D=3.68945557111049, S=0.20269883209762796)"
+      ],
+      "text/html": [
+       "<style>#sk-container-id-12 {color: black;}#sk-container-id-12 pre{padding: 0;}#sk-container-id-12 div.sk-toggleable {background-color: white;}#sk-container-id-12 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-12 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-12 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-12 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-12 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-12 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-12 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-12 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-12 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-12 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-12 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-12 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-12 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-12 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-12 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-12 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-12 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-12 div.sk-item {position: relative;z-index: 1;}#sk-container-id-12 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-12 div.sk-item::before, #sk-container-id-12 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-12 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-12 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-12 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-12 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-12 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-12 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-12 div.sk-label-container {text-align: center;}#sk-container-id-12 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-12 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-12\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>FivePLLogistic(A=0.002006901257671911, B=3.087036820144977,\n",
+       "               C=0.6903113152785875, D=3.68945557111049, S=0.20269883209762796)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-12\" type=\"checkbox\" checked><label for=\"sk-estimator-id-12\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">FivePLLogistic</label><div class=\"sk-toggleable__content\"><pre>FivePLLogistic(A=0.002006901257671911, B=3.087036820144977,\n",
+       "               C=0.6903113152785875, D=3.68945557111049, S=0.20269883209762796)</pre></div></div></div></div></div>"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 38
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Note that when we performed the fit, we provided a weight function based on the magnitude of observed values. This weight scheme ensures our model is not biased towards high signal values--this is especially important because our data spans several orders of magnitude. You can provide your own preferred weight function during fitting.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Both models have been fit to the data, and the best-fit parameters are visible above. The parameters can also be accessed individually:"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T08:16:59.915275Z",
+     "start_time": "2024-11-20T08:16:59.912720Z"
+    }
+   },
+   "source": "five_pl_model.A_",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.002006901257671911"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 39
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since `bio-curve-fit` conforms with the scikit-learn API, we can easily check the $R^2$ using the `score()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T08:17:00.656365Z",
+     "start_time": "2024-11-20T08:17:00.651165Z"
+    }
+   },
+   "source": "five_pl_model.score(x, y)",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9994288917465566"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 40
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The model fit also calculates upper and lower limits of detection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T08:17:01.438536Z",
+     "start_time": "2024-11-20T08:17:01.436692Z"
+    }
+   },
+   "source": [
+    "print(\"Lower Limit of Detection: \", five_pl_model.LLOD_)\n",
+    "print(\"Upper Limit of Detection: \", five_pl_model.ULOD_)"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lower Limit of Detection:  0.04194258485186726\n",
+      "Upper Limit of Detection:  10.000000000000005\n"
+     ]
+    }
+   ],
+   "execution_count": 41
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The default methodology is to use a value 2.5 standard deviations above the fitted curve as the lower limit of detection (where \"standard deviation\" is the standard deviation of the the lowest concentration standard replicates). The upper limit of detection is calculated as the highest concentration standard.\n",
+    "\n",
+    "> Note: You can create your own methodology for calculating the LODs by passing a custom LOD function function into the `fit()` method. See [the code](../../bio_curve_fit/logistic.py) for more details.\n",
+    "\n",
+    "Finally, let's plot the data and the fitted models:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T08:17:02.702992Z",
+     "start_time": "2024-11-20T08:17:02.527290Z"
+    }
+   },
+   "source": [
+    "\n",
+    "def generate_log_spaced_values(start, stop, num_points = 100):\n",
+    "\n",
+    "    # Calculate the logarithmic range\n",
+    "    log_start = np.log10(start)\n",
+    "    log_stop = np.log10(stop)\n",
+    "\n",
+    "    return np.logspace(log_start, log_stop, num_points)\n",
+    "\n",
+    "smoothed_x_values = generate_log_spaced_values(min(df[\"known_concentration\"]), max(df[\"known_concentration\"]), 100)\n",
+    "\n",
+    "four_PL_data = four_pl_model.predict(smoothed_x_values)\n",
+    "five_PL_data = five_pl_model.predict(smoothed_x_values)\n",
+    "\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.scatter(df[\"known_concentration\"], df[\"instrument_response\"], color='blue', alpha=0.6, label='Raw Data')\n",
+    "\n",
+    "# Plot the true model curve\n",
+    "plt.plot(smoothed_x_values, five_PL_data, color='red', linestyle='--', linewidth=2, label='Predicted 5PL Model')\n",
+    "plt.plot(smoothed_x_values, four_PL_data, color='green', linestyle='--', linewidth=2, label='Predicted 4PL Model')\n",
+    "\n",
+    "# Labels and title\n",
+    "plt.xlabel('X values')\n",
+    "plt.ylabel('Y values')\n",
+    "plt.xscale(\"log\")\n",
+    "plt.yscale(\"log\")\n",
+    "plt.title(f'Measured Data and Predicted Models')\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1kAAAIoCAYAAACbCCHjAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuNSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/xnp5ZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACfOElEQVR4nOzdd3QUVR/G8e/uplcILZTQe+9VqiBNqYpKCyJFaSpNUVGKiooU0Qj6IkW6KEURRYqAFBHp0jtIrwlJSNud9481CyEBE0jYJDyfc3Kyc6f9ZgmwT+6dOybDMAxEREREREQkVZidXYCIiIiIiEhmopAlIiIiIiKSihSyREREREREUpFCloiIiIiISCpSyBIREREREUlFClkiIiIiIiKpSCFLREREREQkFSlkiYiIiIiIpCKFLBERERERkVSkkCUi8ghq0KABDRo0cHYZGdqIESMwmUzOLuM/nThxApPJxIwZMxxt6a32pGpMbwoWLEi3bt3ua1+TycSIESNStR4RSd8UskQkw5sxYwYmkwmTycSGDRsSrTcMg6CgIEwmE08++aQTKsy4ChYs6HhvzWYzWbJkoVy5cvTq1YstW7Y80LE/+OADlixZkjqFpmPdunVzvIcmkwk/Pz8qVKjAuHHjiI6OdnZ5KfLFF184NQitXbvW8T7Onj07yW3q1KmDyWSibNmyD7k6EZFbFLJEJNPw8PBg7ty5idrXrVvHP//8g7u7uxOqyvgqVqzIrFmz+OabbxgzZgwNGzbkxx9/pGbNmgwcOPC+j/uohCwAd3d3Zs2axaxZs/jggw8ICAhg8ODBBAcHO6Wet99+m5s3b6Z4P2eHrHh3+7t+4sQJNm3ahIeHhxOqEhG5xcXZBYiIpJYWLVqwcOFCJk2ahIvLrX/e5s6dS5UqVbh8+bITq0sdEREReHt7P9Rz5s2bl86dOydo++ijj+jYsSMTJkygWLFivPzyyw+1pozGxcUlwXvYp08fatSowYIFCxg/fjx58uRJtI9hGERFReHp6Zkm9dz+dySjadGiBT/88AOXL18me/bsjva5c+eSK1cuihUrxrVr15xYoYg86tSTJSKZxvPPP8+VK1dYuXKloy0mJobvvvuOjh07JrmPzWZj4sSJlClTBg8PD3LlykXv3r0TfUBbunQpLVu2JE+ePLi7u1OkSBFGjx6N1WpNsN3hw4dp3749gYGBeHh4kC9fPp577jlCQ0OBe997cud9G/H3zezbt4+OHTuSNWtWHnvsMcf62bNnU6VKFTw9PQkICOC5557j9OnTiY771VdfUaRIETw9PalevTq///77f76X/8XT05NZs2YREBDA+++/j2EYjnWffPIJtWvXJlu2bHh6elKlShW+++67RNcaERHBzJkzHcO/4u93OXnyJH369KFEiRJ4enqSLVs2nnnmGU6cOJGs2pJz/vga+vXrx5IlSyhbtizu7u6UKVOGX375JdG2GzZsoFq1anh4eFCkSBG+/PLL5L9ZSTCbzY574uKvq2DBgjz55JOsWLGCqlWr4unp6TjP9evXefXVVwkKCsLd3Z2iRYvy0UcfYbPZEhz3+vXrdOvWDX9/f7JkyUJwcDDXr19PdP673ZM1e/ZsqlevjpeXF1mzZqVevXr8+uuvjvr27t3LunXrHH9mt9/Xl9o13kvr1q1xd3dn4cKFCdrnzp1Lhw4dsFgsifaJi4tj9OjRFClSBHd3dwoWLMibb76ZaMimYRi899575MuXDy8vLxo2bMjevXuTrCO513ynGzdu8Oqrr1KwYEHc3d3JmTMnTZo0Yfv27Sl6H0Qk/cq4v8YSEblDwYIFqVWrFvPmzaN58+YA/Pzzz4SGhvLcc88xadKkRPv07t2bGTNm8MILLzBgwACOHz/O559/zo4dO9i4cSOurq6A/b4vHx8fBg4ciI+PD2vWrOGdd94hLCyMsWPHAvZA17RpU6Kjo+nfvz+BgYGcOXOGZcuWcf36dfz9/e/rup555hmKFSvGBx984Agz77//PsOHD6dDhw706NGDS5cu8dlnn1GvXj127NhBlixZAPj666/p3bs3tWvX5tVXX+XYsWO0atWKgIAAgoKC7queeD4+PrRt25avv/6affv2UaZMGQA+/fRTWrVqRadOnYiJiWH+/Pk888wzLFu2jJYtWwIwa9YsevToQfXq1enVqxcARYoUAWDr1q1s2rSJ5557jnz58nHixAkmT55MgwYN2LdvH15eXvesKznnj7dhwwYWLVpEnz598PX1ZdKkSbRv355Tp06RLVs2APbs2cMTTzxBjhw5GDFiBHFxcbz77rvkypXrgd6/o0ePAjjOA3Dw4EGef/55evfuTc+ePSlRogSRkZHUr1+fM2fO0Lt3b/Lnz8+mTZsYNmwY586dY+LEiYA9HLRu3ZoNGzbw0ksvUapUKRYvXpzsIYkjR45kxIgR1K5dm1GjRuHm5saWLVtYs2YNTzzxBBMnTqR///74+Pjw1ltvATjeg4dVYzwvLy9at27NvHnzHL2ou3btYu/evUydOpXdu3cn2qdHjx7MnDmTp59+mkGDBrFlyxbGjBnD/v37Wbx4sWO7d955h/fee48WLVrQokULtm/fzhNPPEFMTEyC4yX3mpPy0ksv8d1339GvXz9Kly7NlStX2LBhA/v376dy5copei9EJJ0yREQyuOnTpxuAsXXrVuPzzz83fH19jcjISMMwDOOZZ54xGjZsaBiGYRQoUMBo2bKlY7/ff//dAIw5c+YkON4vv/ySqD3+eLfr3bu34eXlZURFRRmGYRg7duwwAGPhwoV3rfX48eMGYEyfPj3ROsB49913HcvvvvuuARjPP/98gu1OnDhhWCwW4/3330/QvmfPHsPFxcXRHhMTY+TMmdOoWLGiER0d7djuq6++MgCjfv36d60z3p3v2Z0mTJhgAMbSpUsdbXe+VzExMUbZsmWNRo0aJWj39vY2goODEx0zqfd68+bNBmB88803/1lzcs8PGG5ubsaRI0ccbbt27TIA47PPPnO0tWnTxvDw8DBOnjzpaNu3b59hsViM5Pw3GhwcbHh7exuXLl0yLl26ZBw5csT44IMPDJPJZJQvX96xXYECBQzA+OWXXxLsP3r0aMPb29s4dOhQgvY33njDsFgsxqlTpwzDMIwlS5YYgPHxxx87tomLizPq1q2b6Gcu/mcr3uHDhw2z2Wy0bdvWsFqtCc5js9kcr8uUKZPkz01a1JiU3377zfF3bNmyZYbJZHIce8iQIUbhwoUNwzCM+vXrG2XKlHHst3PnTgMwevTokeB4gwcPNgBjzZo1hmEYxsWLFw03NzejZcuWCa77zTffNIAEP6/JvWbDSPx329/f3+jbt+89r1VEMjYNFxSRTKVDhw7cvHmTZcuWcePGDZYtW3bXoYILFy7E39+fJk2acPnyZcdXlSpV8PHx4bfffnNse/t9MTdu3ODy5cvUrVuXyMhIDhw4AODoqVqxYgWRkZGpdk0vvfRSguVFixZhs9no0KFDgroDAwMpVqyYo+6//vqLixcv8tJLL+Hm5ubYP36oVmrw8fEB7O9JvNvfq2vXrhEaGkrdunWTPRTq9v1jY2O5cuUKRYsWJUuWLMk6RkrO37hxY0cPGkD58uXx8/Pj2LFjAFitVlasWEGbNm3Inz+/Y7tSpUrRtGnTZF0P2O+ly5EjBzly5KBo0aK8+eab1KpVK0EPCkChQoUSHXfhwoXUrVuXrFmzJvjzbty4MVarlfXr1wOwfPlyXFxcEtwfZ7FY6N+//3/Wt2TJEmw2G++88w5mc8KPBsmZ6v1h1HinJ554goCAAObPn49hGMyfP5/nn38+yW2XL18OkGiilkGDBgHw008/AbBq1SpiYmLo379/gut+9dVX7/uak5IlSxa2bNnC2bNnU3TNIpJxaLigiGQqOXLkoHHjxsydO5fIyEisVitPP/10ktsePnyY0NBQcubMmeT6ixcvOl7v3buXt99+mzVr1hAWFpZgu/j7rQoVKsTAgQMZP348c+bMoW7durRq1YrOnTs/UKgpVKhQoroNw6BYsWJJbh8/xPHkyZMAibZzdXWlcOHC913P7cLDwwHw9fV1tC1btoz33nuPnTt3JrjfJbnPZbp58yZjxoxh+vTpnDlzJsH9XvHv9b2k5Py3B6d4WbNmddyTd+nSJW7evJnke12iRAnHh/f/4uHhwY8//gjYZxosVKgQ+fLlS7TdnX/WYP/z3r17Nzly5Ejy2PE/pydPniR37tyO4Ht7nf/l6NGjmM1mSpcu/Z/bJuVh1HgnV1dXnnnmGebOnUv16tU5ffr0XX+hcvLkScxmM0WLFk3QHhgYSJYsWRx/V+72dyZHjhxkzZo1QVtyrzkpH3/8McHBwQQFBVGlShVatGhB165dU+3vpYg4n0KWiGQ6HTt2pGfPnpw/f57mzZs77k+6k81mI2fOnMyZMyfJ9fEfnq5fv079+vXx8/Nj1KhRFClSBA8PD7Zv387rr7+e4Cb3cePG0a1bN5YuXcqvv/7KgAEDGDNmDH/88Qf58uW7a9C4cwKN2905u5zNZsNkMvHzzz8neYP/nR9g09Lff/8N4Pjw+vvvv9OqVSvq1avHF198Qe7cuXF1dWX69OlJTrmdlP79+zN9+nReffVVatWqhb+/PyaTieeee+4/JxRI6fmTev+ABMEuNVgsFho3bvyf2yU1k6DNZqNJkyYMHTo0yX2KFy/+wPU9KGfV2LFjR6ZMmcKIESOoUKHCf4bE1HwA84Ncc4cOHahbty6LFy/m119/ZezYsXz00UcsWrTIcT+piGRsClkikum0bduW3r1788cff7BgwYK7blekSBFWrVpFnTp17jlN9tq1a7ly5QqLFi2iXr16jvbjx48nuX25cuUoV64cb7/9Nps2baJOnTpMmTKF9957z/Hb8DtnU4v/DXpyFClSBMMwKFSo0D0/yBUoUACw/8a9UaNGjvbY2FiOHz9OhQoVkn3OpISHh7N48WKCgoIoVaoUAN9//z0eHh6sWLEiwXPJpk+fnmj/u33g/e677wgODmbcuHGOtqioqGTNQJeS8ydHjhw58PT05PDhw4nWHTx48L6OmVJFihQhPDz8P0NagQIFWL16NeHh4QmCdnLqLFKkCDabjX379lGxYsW7bne3P7OHUWNSHnvsMfLnz8/atWv56KOP7nlem83G4cOHHT+rABcuXOD69euOvyu3/525vVfp0qVLiWYcTe41303u3Lnp06cPffr04eLFi1SuXJn3339fIUskk9A9WSKS6fj4+DB58mRGjBjBU089ddftOnTogNVqZfTo0YnWxcXFOT7Ux/d23N67ERMTwxdffJFgn7CwMOLi4hK0lStXDrPZ7Bi25ufnR/bs2RPdr3Hnse6lXbt2WCwWRo4cmajHxTAMrly5AkDVqlXJkSMHU6ZMSTAz2owZM1I8Zfadbt68SZcuXbh69SpvvfWW48O3xWLBZDIl6Jk7ceJEkg8d9vb2TrIOi8WS6Lo+++yze/b23b5vcs+fHBaLhaZNm7JkyRJOnTrlaN+/fz8rVqy4r2OmVIcOHdi8eXOS57t+/brjZ65FixbExcUxefJkx3qr1cpnn332n+do06YNZrOZUaNGJeotvP3P4m5/Zg+jxqSYTCYmTZrEu+++S5cuXe66XYsWLQASzfg3fvx4AMesk40bN8bV1ZXPPvsswXUnNVNgcq/5TlarNdGw15w5c5InT55E08mLSMalniwRyZSSMyV0/fr16d27N2PGjGHnzp088cQTuLq6cvjwYRYuXMinn37K008/Te3atcmaNSvBwcEMGDAAk8nErFmzEgWBNWvW0K9fP5555hmKFy9OXFwcs2bNwmKx0L59e8d2PXr04MMPP6RHjx5UrVqV9evXc+jQoWRfW5EiRXjvvfcYNmwYJ06coE2bNvj6+nL8+HEWL15Mr169GDx4MK6urrz33nv07t2bRo0a8eyzz3L8+HGmT5+eons/zpw5w+zZswF779W+fftYuHAh58+fZ9CgQfTu3duxbcuWLRk/fjzNmjWjY8eOXLx4kZCQEIoWLZpoWu0qVaqwatUqx8N4CxUqRI0aNXjyySeZNWsW/v7+lC5dms2bN7Nq1aoEU53fTUrOn1wjR47kl19+oW7duvTp04e4uDg+++wzypQpc9/HTIkhQ4bwww8/8OSTT9KtWzeqVKlCREQEe/bs4bvvvuPEiRNkz56dp556ijp16vDGG29w4sQJSpcuzaJFi5J1H1vRokV56623GD16NHXr1qVdu3a4u7uzdetW8uTJw5gxYwD7n9nkyZN57733KFq0KDlz5qRRo0YPpca7ad26Na1bt77nNhUqVCA4OJivvvrKMfz3zz//ZObMmbRp04aGDRsC9p7LwYMHM2bMGJ588klatGjBjh07+PnnnxM89BiS/+dypxs3bpAvXz6efvppKlSogI+PD6tWrWLr1q0Jem9FJINzzqSGIiKp5/Yp3O/lbtORf/XVV0aVKlUMT09Pw9fX1yhXrpwxdOhQ4+zZs45tNm7caNSsWdPw9PQ08uTJYwwdOtRYsWKFARi//fabYRiGcezYMaN79+5GkSJFDA8PDyMgIMBo2LChsWrVqgTni4yMNF588UXD39/f8PX1NTp06GBcvHjxrlO4X7p0Kcnr+f77743HHnvM8Pb2Nry9vY2SJUsaffv2NQ4ePJhguy+++MIoVKiQ4e7ublStWtVYv369Ub9+/WRP4Q4YgGEymQw/Pz+jTJkyRs+ePY0tW7Ykuc/XX39tFCtWzHB3dzdKlixpTJ8+PdGU4YZhGAcOHDDq1atneHp6Jpge+9q1a8YLL7xgZM+e3fDx8TGaNm1qHDhwwChQoECSU77f7/mBJKfRTuo869atM6pUqWK4ubkZhQsXNqZMmZLkMZMSP4X7f7nXdPk3btwwhg0bZhQtWtRwc3MzsmfPbtSuXdv45JNPjJiYGMd2V65cMbp06WL4+fkZ/v7+RpcuXRyPFrjXFO7xpk2bZlSqVMlwd3c3smbNatSvX99YuXKlY/358+eNli1bGr6+vokeA5DaNSbl9inc7+XOKdwNwzBiY2ONkSNHGoUKFTJcXV2NoKAgY9iwYY5HMMSzWq3GyJEjjdy5cxuenp5GgwYNjL///jvJn4vkXvPtf7ejo6ONIUOGGBUqVDB8fX0Nb29vo0KFCsYXX3xxz2sSkYzFZBipfHeviIiIiIjII0z3ZImIiIiIiKQihSwREREREZFUpJAlIiIiIiKSihSyREREREREUpFCloiIiIiISCpSyBIREREREUlFehjxPdhsNs6ePYuvry8mk8nZ5YiIiIiIiJMYhsGNGzfIkycPZvO9+6oUsu7h7NmzBAUFObsMERERERFJJ06fPk2+fPnuuY1C1j34+voC9jfSz8/PydWIiIiIiIizhIWFERQU5MgI96KQdQ/xQwT9/PwUskREREREJFm3EWniCxERERERkVSkkCUiIiIiIpKKFLKSEBISQunSpalWrZqzSxERERERkQzGZBiG4ewi0quwsDD8/f0JDQ295z1ZVquV2NjYh1iZiHO4urpisVicXYaIiIjIQ5fcbACa+OKBGIbB+fPnuX79urNLEXlosmTJQmBgoJ4dJyIiInIXClkPID5g5cyZEy8vL33olEzNMAwiIyO5ePEiALlz53ZyRSIiIiLpk0LWfbJarY6AlS1bNmeXI/JQeHp6AnDx4kVy5sypoYMiIiIiSdDEF/cp/h4sLy8vJ1ci8nDF/8zrPkQRERGRpClkPSANEZRHjX7mRURERO5NIUtERERERCQVKWSJiIiIiIikIoWsR1C3bt0wmUyYTCZcXV0pVKgQQ4cOJSoq6qHWUbBgQUcdnp6eFCxYkA4dOrBmzZoUH6tbt260adMm9YsUEREREUkhhax0wGaDQ4dg61b7d5st7c/ZrFkzzp07x7Fjx5gwYQJffvkl7777btqf+A6jRo3i3LlzHDx4kG+++YYsWbLQuHFj3n///Ydei4iIiIhIalDIcrIdO2DgQOjfHwYPtn8fONDenpbc3d0JDAwkKCiINm3a0LhxY1auXOlYf+XKFZ5//nny5s2Ll5cX5cqVY968eY71y5YtI0uWLFitVgB27tyJyWTijTfecGzTo0cPOnfufM86fH19CQwMJH/+/NSrV4+vvvqK4cOH884773Dw4EHAPl3+iy++SKFChfD09KREiRJ8+umnjmOMGDGCmTNnsnTpUkfP2Nq1awF4/fXXKV68OF5eXhQuXJjhw4drVjwRERGRDMAZHRGpRc/JcqIdO2DUKLh8GfLlA29viIiAbdvg5El45x2oVCnt6/j777/ZtGkTBQoUcLRFRUVRpUoVXn/9dfz8/Pjpp5/o0qULRYoUoXr16tStW5cbN26wY8cOqlatyrp168iePbsj3ACsW7eO119/PcX1vPLKK4wePZqlS5cydOhQbDYb+fLlY+HChWTLlo1NmzbRq1cvcufOTYcOHRg8eDD79+8nLCyM6dOnAxAQEADYQ9yMGTPIkycPe/bsoWfPnvj6+jJ06NAHe9NEREREJM3s2AEzZtg/F0dE2D8nV6kC3bo9nM/HD0ohy0lsNpg50x6wSpWC+Fmx/fzsy/v3wzffQIUKYE6D/sZly5bh4+NDXFwc0dHRmM1mPv/8c8f6vHnzMnjwYMdy//79WbFiBd9++y3Vq1fH39+fihUrsnbtWqpWrcratWt57bXXGDlyJOHh4YSGhnLkyBHq16+f4toCAgLImTMnJ06cAMDV1ZWRI0c61hcqVIjNmzfz7bff0qFDB3x8fPD09CQ6OprAwMAEx3r77bcdrwsWLMjgwYOZP3++QpaIiIhIOhU/0iu+98ow7J+Vjx+H3bth/Pj0H7Q0XNBJjhyxB6l8+W4FrHgmk7193z77dmmhYcOG7Ny5ky1bthAcHMwLL7xA+/btHeutViujR4+mXLlyBAQE4OPjw4oVKzh16pRjm/r167N27VoMw+D333+nXbt2lCpVig0bNrBu3Try5MlDsWLF7qs+wzASPI8pJCSEKlWqkCNHDnx8fPjqq68S1HI3CxYsoE6dOgQGBuLj48Pbb7+drP1EREREHiXpZWiezQZjx9rDVFwcuLqCu7v9e1ycvf2TT9L/0EH1ZDlJaChERdm7PpPi5QVnz9q3Swve3t4ULVoUgGnTplGhQgW+/vprXnzxRQDGjh3Lp59+ysSJEylXrhze3t68+uqrxMTEOI7RoEEDpk2bxq5du3B1daVkyZI0aNCAtWvXcu3atfvqxQL7/WCXLl2iUKFCAMyfP5/Bgwczbtw4atWqha+vL2PHjmXLli33PM7mzZvp1KkTI0eOpGnTpvj7+zN//nzGjRt3X3WJiIiIZEZOH5pnGBAeDhcvcmrrJTxWXsLL2oAIw5fw8Fs9We7u9tcbNtiDYMmSD6G2+6SQ5ST+/uDhYf9B9vNLvD4y0r7e3z/tazGbzbz55psMHDiQjh074unpycaNG2ndurVj4gqbzcahQ4coXbq0Y7/4+7ImTJjgCFQNGjTgww8/5Nq1awwaNOi+6vn0008xm82OKdk3btxI7dq16dOnj2Obo0ePJtjHzc3NMQlHvPj7zN566y1H28mTJ++rJhEREZHM6PahedHRqTg0z2azdz25ud1qCw+H99+HCxfg4sVb3y9etPc+AAWBacBj7lvZbq6Ki4v91hmbzb6JyQRXr8Lff6fvkKXhgkkICQmhdOnSVKtWLc3OUbSo/d6rf/6x/zDfzjDs7aVL27d7GJ555hksFgshISEAFCtWjJUrV7Jp0yb2799P7969uXDhQoJ9smbNSvny5ZkzZw4NGjQAoF69emzfvp1Dhw4lqyfrxo0bnD9/ntOnT7N+/Xp69erFe++9x/vvv+/oaStWrBh//fUXK1as4NChQwwfPpytW7cmOE7BggXZvXs3Bw8e5PLly8TGxlKsWDFOnTrF/PnzOXr0KJMmTWLx4sWp8G6JiIiIZHzxQ/N27IBr1+y/5L950/792jV7e5JD886ehT/+gMWL4YsvYPhw6NEDnnwSqla13/fi7m4PVLezWODDD2H6dPjpJ/jrLzh1yhGwbhdgvYSbm30Xk8n+3c0NrFaIidFwwQypb9++9O3bl7CwMPzTqCvJbIbgYPssgvH3Znl52X+o//kHsmeHrl3TZtKLpLi4uNCvXz8+/vhjXn75Zd5++22OHTtG06ZN8fLyolevXrRp04bQO8Yv1q9fn507dzpCVkBAAKVLl+bChQuUKFHiP8/7zjvv8M477+Dm5kZgYCA1a9Zk9erVNGzY0LFN79692bFjB88++ywmk4nnn3+ePn368PPPPzu26dmzp2MSjvDwcH777TdatWrFa6+9Rr9+/YiOjqZly5YMHz6cESNGpMp7JiIiInI/bDb7ffehofZRS0WLPrzPfLc7dAh++80erCxmg0CXy+TjHwKtZ8gVd4bA6DO4/uDCoUPvJOw1Cg6GVav++wTnzydc9vQEX1+4ccO+bDbbP/TmzAk5ckDOnJyIzMHMn3NyzFQkyUMahn03X9/7u+aHxWQYd/ajSLz4kBUaGorfHWP6oqKiOH78OIUKFcLDw+O+z7Fjh32Wwf377SHew8Peg9W1a/qfNUUeTan1sy8iIvIocsr9T/Ef92+fbW3DBk4Om8ypjf+Q1/iHPJzBg+hEu54jkA3fnuOZZ25r7NoVZs1K+lxmM+TKBYGB0KaN/ZlEt9u0yX6vTM6ckC2bvYvqNlu2wFNP2QOoxUKC4YJxcfaeLH9/+PFHqFEj5W/Fg7hXNriTerKcrFIl+zTt6eG3GSIiIiKSdtLs/ierFc6csQ+ROnkSTpy49frUKTh92j5bxO0HP3eOAhvmUuCuB7XLxQXO/xNHgtjwxBP2oJQ7d+Kv7NkTBacEate+5/myZoUiReDoUXsIjYu7tc5ksn9WLlLEvl16ppCVDpjNULy4s6sQERERkbRy+/1Pt03WDNhvF4m//2nWrCR+2W4Y9kkiDMMeZOLdvAllythD1O1pJCmnTiUMWfnyOV5eIwtnzfk4Z87HGXM+zpnycsacj1OxeThLHobmvuN5Q50727/SQNGi9h6qqCiIjbU/UzYuzt6jlT27fSr3mjUf3rwF90shS0REREQkjSW4/8liDwsmkz03xcZCbGQsR389xZlpRwiKOWrvyjlyxP792DH7jr16wZdf3jqop6d9KNS9ApaXF+TPn3imtYoVObb8AE265eWf6z6Yzfaa4ofmxcaCzQwBAVCuYpq8JUm6fd6CS5egYEH7+2W1wvXr9lu3Hua8BfdLIUtEREREJI3t2QOhV63k4xxX3W/1IplMMME6gBdjv8DlshV63uMgx48nbqtc2d7dU7AgFChg/7r9dUBAwnux4nl6UrBpCWo8Dpd/soeq27Oa2Wyfza9Ro4c/4qpSJfutXPHzFty4YZ+3oFq1jDNvgUKWiIiIiEhqunEDDh6EAwccX402HuBqzBEsWMnjGUmcydWxeZjJHxesSR/LzQ0KFYLChe3j5O60cuV9l2k2w5AhcO6cvdzYWHsvVnyvVokSMHiwc3qNMvq8BQpZIiIiIpJpPbTp0g8dgj597KHqzJlEq7Pd9jrIeoLjLsUcy3vN5dhpqshRilK6VRFKPVnUPrtDkSKQN++9J5J4QJUq2SfcmD7DYNs2GxE3rXh526hU2crznWyUKe8O3HqgcJwtjosRF7EZNgzDwGbYEn0Z2NuLBhTFzXJr34sRFzkdehoDw7Fv/Ovbv3u6eFIlT5UMPW+BQpaIiIiIZEqpNl16eDjs3Wsf87dnj/11jx7w3HO3tvHxwbZmNVEucNMTbrpif+1ifx3p7sIxS248TpfDGmPFarKHvTj/Q8wpcIbZpufw9Imhc6cY/LIcJiZ6L9F7oonZGUOsLRZXsytTW01NUNbYjWP58dCPxNpiibPFJflltVlpVrQZXz31VYJ9S3xegpPXT2I1rFhtVowAA5rcWr8Z+GI5fGn+kl5VejnaD185TOkvSifrbTv+ynEKZinoWJ63Zx6vrnj1P/crnq04B/sdTNY50iuFLBERERHJdG6fLt1mS9506dvPbefske2EHtxD2OnDhJ87xY3LZ7gReZ0b7nDDDW64w3OXoeuWco6QFRoVSu7pRbn57r0qigNO4zV/HsbJkvZFwJp1D3GPDwQgHJiyL+m9PV08E4WsI1eP8Pup3//zvbgUeSlRW4w1hmhr4udi3clm2BIsm03J7wa883G8pqTuDUvGfhmRQpaIiIiIZBrnw89z4NIh3p58gR3GJUwVL2PyuorN4wo29yvEuV3hvPsVnpxbmNOen2MueWs8Wr/l/dj8z2b7ghnI++/XHSqcxz5t+r88XT25GXczWfUVKxnNxdBb9z/FuboT89+7EWuLTdTmarl1X5fZZMbF7IKL2QVXsysuZhcsZgsWk4UsHlkS7VsmRxmyeGTBbDJjMVmwmC2O12aT2bFvXt+Eb4Cvuy/tSrXDhAmzyZzgy2S61WbChLebd4J9y+cqz8tVX3bsazKZMGFyfI9vy+GVI1nvZXqmkCVpqlu3bly/fp0lS5YA0KBBAypWrMjEiRMfah1r166lYcOGXLt2jSxZsjzUczvb/Vx7wYIFefXVV3n11VfTtDYREZHkCIsO45+wfzgTdsb+/cYZ++sb/7Dg6QV4uXo5tv16+9e8/dvbdw1I8fwuHYUqleFGmOMmraTCSFIi+vSAdv9zLLuaXamQqwIeLh54unri6eLp+O7h4uFY9nDxoOrjBVi90D6EMTISLH6VyRG+gMYN3ShVzB03ixtuFjdcLa63XptdEwSqeBOaTmB80/G4mF1S1MMEsKzjshRtHy+Pbx6+7/D9fe3boGADGhRscF/7ZjQKWY+gbt26MXPmTABcXV3Jnz8/Xbt25c0338TFJW1/JBYtWoSra+J/JJLysINRgwYNWLduXYK23r17M2XKFABOnDhBoUKFHOsCAgKoUqUKH330EZX+HW+Q0hAZ/2dx+3ni9e3bly+++ILg4GBmzJhx/xcmIiKSwZwKPcWrv7zK8evHOX7tOKHRoXfd9kzYGYpluzWJRC6fXPc8tsmALFEQcBPMkRH251AVs+/fsVxHatny4n/0H/yCiuJbqAS+QUXx9fDHx80HX3dffN188XX3TXhMk4mdL+1M9vU9Wfv2yTjyULRoh/uajCOp4CXpg0LWI6pZs2ZMnz6d6Oholi9fTt++fXF1dWXYsGGJto2JicHNzS2Jo6RcQEBAqhwnrfTs2ZNRo0Y5lr28vBJts2rVKsqUKcM///zDgAEDaN68OQcOHLjvIBgUFMT8+fOZMGECnp6eAERFRTF37lzy589/X8cUERFJbwzD4Fz4OQ5ePsiBywc4eOXW92GPDUswuYK7xZ3FBxYn67j/nP6bYnF+kMserirnrkxb9xeouWw6OSMgeyRki4RsN+3BKutNwDBzwFSKE3UrU/C2+386l+8M5Tun6nUnJSPPmifJk0FmmpfU5u7uTmBgIAUKFODll1+mcePG/PDDD4C9d6VNmza8//775MmThxIlSgBw+vRpOnToQJYsWQgICKB169acOHHCcUyr1crAgQPJkiUL2bJlY+jQoYluXGzQoEGCIWjR0dG8/vrrBAUF4e7uTtGiRfn66685ceIEDRs2BCBr1qyYTCa6desGgM1mY8yYMRQqVAhPT08qVKjAd999l+A8y5cvp3jx4nh6etKwYcMEdd6Ll5cXgYGBji8/P79E22TLlo3AwECqVq3KJ598woULF9iyZUuyjp+UypUrExQUxKJFixxtixYtIn/+/I4esnjR0dEMGDCAnDlz4uHhwWOPPcbWrVsTbJOca9+wYQN169bF09OToKAgBgwYQERExH1fg4iISFIW7l1I/+X9qTe9Hlk/ykre8Xlp9E0j+izvw6dbPmXF0RWcuH6CfZcSzvaQ0zsnXq5eWEwWCmUpRIOCDehcvjNv1H6dzyq9yeKsL/PnmRac/a4A9Sq3g9tGkFTOXZme5b/mxY0BdNsJLQ6ZCDhbkh1hnfnEmEgLrw1kdw2jqvvf7B/2jdKOpAn1ZAkAnp6eXLlyxbG8evVq/Pz8WPnvA+5iY2Np2rQptWrV4vfff8fFxYX33nuPZs2asXv3btzc3Bg3bhwzZsxg2rRplCpVinHjxrF48WIaNWp01/N27dqVzZs3M2nSJCpUqMDx48e5fPkyQUFBfP/997Rv356DBw/i5+fn6OUZM2YMs2fPZsqUKRQrVoz169fTuXNncuTIQf369Tl9+jTt2rWjb9++9OrVi7/++otBgwYl632YM2cOs2fPJjAwkKeeeorhw4cn2Zt1+/sG9t6+B9G9e3emT59Op06dAJg2bRovvPACa9euTbDd0KFD+f7775k5cyYFChTg448/pmnTphw5coSAgIBkXfvRo0dp1qwZ7733HtOmTePSpUv069ePfv36MX369Ae6DhERefTEWGPYeX4np0NP0750+wTrvtn9DcsO3fveHz93vyRnoTvU7xC53LLism0H/P47fLcRNv4E164lPsgdv+wMyGbidd/JnLyZk10uVYhy9cVs/neiiTiwmsDfF9L5ABvJwBSy0sL48fav/1K5Mvzbe+TQqhVs3/7f+w4caP96QIZhsHr1alasWEH//v0d7d7e3kydOtUxTHD27NnYbDamTp3qmH5z+vTpZMmShbVr1/LEE08wceJEhg0bRrt27QCYMmUKK1asuOu5Dx06xLfffsvKlStp3LgxAIULF3asjx9amDNnTsdQvOjoaD744ANWrVpFrVq1HPts2LCBL7/8kvr16zN58mSKFCnCuHHjAChRogR79uzho48+uud70bFjRwoUKECePHnYvXs3r7/+OgcPHkzQw3S769evM3r0aHx8fKhevfo9j/1fOnfuzLBhwzh58iQAGzduZP78+QlCVkREBJMnT2bGjBk0b94cgP/973+sXLmSr7/+miFDhiTr2seMGUOnTp0cPYrFihVj0qRJjvfOw8Pjga5FREQyt9Ohp/njnz/Y/M9m/vjnD7af2060NRofNx/alGyDxXzrwbkVclVwhKx8fvkom7MsJbOVpGT2kpTIXoKS2UuSyztXklN75/XLC/36QUjI3Ytxd4eqVaFu3QTNWbPC3jIdOHrU/nwsI+7WOpPJ/lDiIkXs24mkBYWstBAWluSTvhMJCkrcdulS8vYNC0t5XbdZtmwZPj4+xMbGYrPZ6NixIyNGjHCsL1euXIL7sHbt2sWRI0fw9U14o2dUVBRHjx4lNDSUc+fOUaNGDcc6FxcXqlatetdnHezcuROLxUL9+vWTXfeRI0eIjIykSZMmCdpjYmIcQ+v279+foA7AEcjupVevW2PBy5UrR+7cuXn88cc5evQoRYoUcayrXbs2ZrOZiIgIChcuzIIFC8iV69432f6XHDly0LJlS2bMmIFhGLRs2ZLs2bMn2Obo0aPExsZSp04dR5urqyvVq1dn//79QPKufdeuXezevZs5c+Y42gzDwGazcfz4cUqVKvVA1yIiIplLWHQYyw8vZ83xNaw+vppj144luV14TDh/X9iH541y/07oAJ3LdeXxQo9TPld5snllS7xTXJy9F2rVKvjtN5g713FvFQD16iUMWdmywWOPQZ069q8qVexB6w5Fi0KNGhAVZZ8q/fJl+6lcXCB7dnB1hZo17duJpAWFrLTg5wd57zFnaLwcSTwDIEeO5O2bxL1CKdGwYUMmT56Mm5sbefLkSTSroLd3wucahIeHU6VKlQQfzG+VfH/PMogfapcS4eHhAPz000/kveN9ck/iH9kHER9Wjhw5kiBkLViwgNKlS5MtW7ZUnfWwe/fu9OvXD4CQe/3W7gGFh4fTu3dvBgwYkGidJtoQEZE7nb1xlue/f/6u64sFFKNmvprkM2rx+Ue52P+XfWpyLy+oUqU43boVJ1v85LyGAYcPw8qVt4JV6G0zB65fD888c2u5fn3o0sX+/bHH7PdPJeOBtmYzBAfDyZP2318XLAgWC1itcP26/eNW167c14x+IsmhkJUWHmQo353DB9OIt7c3RVPw65vKlSuzYMECcubMmeRkEAC5c+dmy5Yt1KtXD4C4uDi2bdtG5cqVk9y+XLly2Gw21q1b5xgueLv4njSr1epoK126NO7u7pw6dequPWClSpVyTOIR748//vjvi7zDzp07Hdd1u6CgoAShK7U0a9aMmJgYTCYTTZs2TbS+SJEiuLm5sXHjRgoUKADY75XbunWrY+hfcq69cuXK7Nu3L0V//iIikrmdCTvDj4d+5IeDP/B4occZVPvW/bwlspUgt09uzoWfw83iRq18tahXoB4189WkRt4aZPPKxo4d9o8+Bw/ae44Mw56Fjh2D3bvh6ycXU3jfMnu4uu0hvols354wZOXKBd98c1/XVKkSvPMOzJwJ+/fDjRvg4QHVqtkD1h1zS4mkKoUsSZZOnToxduxYWrduzahRo8iXLx8nT55k0aJFDB06lHz58vHKK6/w4YcfUqxYMUqWLMn48eO5fv36XY9ZsGBBgoOD6d69u2Pii5MnT3Lx4kU6dOhAgQIFMJlMLFu2jBYtWuDp6Ymvry+DBw/mtddew2az8dhjjxEaGsrGjRvx8/MjODiYl156iXHjxjFkyBB69OjBtm3b/vM5U0ePHmXu3Lm0aNGCbNmysXv3bl577TXq1atH+fLlU/ReXbp0yRHQ4uXOnfs/hxRaLBbHsD+LxZJovbe3Ny+//DJDhgwhICCA/Pnz8/HHHxMZGcmLL74IkKxrf/3116lZsyb9+vWjR48eeHt7s2/fPlauXMnnn3+eomsVEZGMyTAMdl/YzQ8Hf+CHQz/w19m/HOuu3ryaIGSZTCYmNJ1ANq9s1A6qneDBv2CfTGLsWHs+io1NfK7t28G250O48mfildmyweOPQ5Mm9u+3PY8yNVSqBBUq3P5MKvsQQfVgSVpTyJJk8fLyYv369bz++uu0a9eOGzdukDdvXh5//HFHz9agQYM4d+4cwcHBmM1munfvTtu2bQkNvfsDBCdPnsybb75Jnz59uHLlCvnz5+fNN98EIG/evIwcOZI33niDF154ga5duzJjxgxGjx5Njhw5GDNmDMeOHSNLlixUrlzZsV/+/Pn5/vvvee211/jss8+oXr06H3zwAd27d79rHW5ubqxatYqJEycSERFBUFAQ7du35+23307xezV37lzmzp2boG306NHJOtbdegnjffjhh9hsNrp06cKNGzeoWrUqK1asIOu/d+4m59rLly/PunXreOutt6hbty6GYVCkSBGeffbZFF+riIhkLEeuHmHO7jnM2TOHw1cPJ7nN2RtniYyNTBCmni179/8jDh2CTWuiaBi5mieNHyhr/E0znw3YDBOxsfb7ohbbWjCEP+33T9Wtaw9VjRtDxYppnnj0TCpxBpNxt1kJHmEhISGEhIRgtVo5dOgQoaGhiT78RkVFcfz4cQoVKqTZ2OSRop99EZGMaeHehXT4rkOS6yoFVqJViVa0KtGKSoGVkpztL5GrV+GnnzgdspSsW37Bh1vPW6zl+zcHLGUwDHvIKmg7xleDD1FveH24j3uyRdKDsLAw/P39k8wGd1JPVhL69u1L3759HW+kiIiISEYSa40lMjYSf49bn2MaFWqEi9mFOFscJkw0KNiAp0s/zZPFnyS/fzInPvrnH1i0CJYssU9SYbVy51zJUbhTymoPWSaTfUa/o9GF2RlYmHrKV/KIUMgSERERySTOhJ3hq21f8dX2r3iuzHNMaDbBsS6bVzZeqfEKubxz8Xy558nnly9lB4+OhlKl4N+Zfm93iewsNz/FCs/WrHNpTKTp1izFcXH2mf3umEdKJFNTyBIRERHJwAzD4LcTv/HF1i9YcmAJVsM+K+/0ndN5r9F7eLvdCjyfPPFJ8g569izs2gXNm99qc3eHli1hwQL7cpEi0Lo1Jyu1ofbg2ly+ZsFiA1cDTNhnGIyfaTAgAMqVS6ULFskAFLJEREREMqCbsTeZvnM6n/35GQcuH0iwzmKy8Hjhx7kedT1ByLqnsDD4/nuYNQvWrrXfO3Xpkv2BV/F69rT3ZrVvD2XKgMlEkA3qL4flyyEmJvEMg56e0KiRJp+QR4tCloiIiEgGEhkbyWdbPmP8H+O5GHExwbpAn0B6Ve5Fzyo9kzccMDYWfv3VHqyWLrXPUuE4UST8/LM9UMV7/HH7123MZhgyBM6ds880GB196zlZ7u72cDV4sKZNl0eLQpaIiIhIBmLClChg1S9Qn77V+tKmZBtcLa7/fZAdO2D6dJg/395bdaeiReH555P9xN5KlWD8eJgxA7Ztg4gI8PaGqlUhOFgP/pVHj0KWiIiISDoWHhOOj5uPY9nT1ZPXar7Gm6vf5JkyzzDssWFUDKyY/APabNCmDZw6lbA9WzZ47jno0gWqV7d3RaWAHvwrcotCloiIiEg6FBoVykcbP+KLrV+w5+U9BPnfmiy9T7U+tC3ZlhLZS9z7IIYBf/+dcNYJsxm6d4cRI+zj+Vq1sgerpk3Bze2BataDf0XsFLJERERE0pEYawxT/prCqHWjuHLzCgCfbPqET5t/6tjGz90PL4sfK1bA+fMQGGi/Vcol/pPd9ev24YBffQUHDsDRo1C48K2TvPiifadnn4UsWR7atYk8KtSBK2mqW7dutGnTxrHcoEEDXn311Ydex9q1azGZTFy/fv2hn9vZ7ufaCxYsyMSJE9OsJhERScwwDL7d+y2lQkrxyi+vOAKWm8UNX3ffBNvOm2e/3+m556BvX/v3qlXhp7F74eWXIW9eGDjQHrAApk1LeLJ8+aB3bwUskTSikPUI6tatGyaTCZPJhJubG0WLFmXUqFHExcWl+bkXLVrE6NGjk7Wts4KRYRg0b94ck8nEkiVLHO0nTpxwvG8mk4ls2bLxxBNPsGPHDsc2KQ2R8X8WL730UqJ1ffv2xWQy0a1btwe4GhERyQh+P/k7Nb+uybPfPcuxa8cc7Z3KdeJgv4O81+g9R9u8eTBgAOzbZ58M0Iiz8kTEYibsbkTLoWVhyhT7zIDx6tWzJzAReWgUsh5RzZo149y5cxw+fJhBgwYxYsQIxo4dm+S2MTExqXbegIAAfH19/3tDJ5o4cSKme9zsu2rVKs6dO8eKFSsIDw+nefPmDxQEg4KCmD9/Pjdv3nS0RUVFMXfuXPLnz3/fxxURkfTvSuQVuizuQr0Z9fjzzJ+O9kaFGvFXz7+Y3W42BbMUdLTHxdlvpbp+HSwW6MIsDsQUZkFsOxoavzm2M7y9oU8fexJbt84+0YWIPDQKWY8od3d3AgMDKVCgAC+//DKNGzfmhx9+AG4N8Xv//ffJkycPJUrYb6o9ffo0HTp0IEuWLAQEBNC6dWtOnDjhOKbVamXgwIFkyZKFbNmyMXToUAzDSHDeO3t6oqOjef311wkKCsLd3Z2iRYvy9ddfc+LECRo2bAhA1qxZE/To2Gw2xowZQ6FChfD09KRChQp89913Cc6zfPlyihcvjqenJw0bNkxQ573s3LmTcePGMe3OYRW3yZYtG4GBgVStWpVPPvmECxcusGXLlmQdPymVK1cmKCiIRYsWOdoWLVpE/vz5qXTHnLfR0dEMGDCAnDlz4uHhwWOPPcbWrVsTbJOca9+wYQN169bF09OToKAgBgwYQERExH1fg4iI3B+zycyvR391LJfNWZblHZezqssqquSpkmj7lSvtkwKazfY5KyxmG0HGrVkCD1OMQS6fsmrGGQgJsT84WEQeOoUsAcDT0zNBj9Xq1as5ePAgK1euZNmyZcTGxtK0aVN8fX35/fff2bhxIz4+PjRr1syx37hx45gxYwbTpk1jw4YNXL16lcWLF9/zvF27dmXevHlMmjSJ/fv38+WXX+Lj40NQUBDff/89AAcPHuTcuXN8+qn9ht8xY8bwzTffMGXKFPbu3ctrr71G586dWbduHWAPg+3ateOpp55i586d9OjRgzfeeOM/34PIyEg6duxISEgIgYGByX7f4MF7+7p378706dMdy9OmTeOFF15ItN3QoUP5/vvvmTlzJtu3b6do0aI0bdqUq1evAsm79qNHj9KsWTPat2/P7t27WbBgARs2bKBfv34PdA0iIpJyWT2zMqHpBLJ6ZOXLJ79kZ++dNC/WPOkRFfv3c3rNYWJj7ZMAmkzwvevz/GMK4leXFjzt/TNVvA/wqTGA7Uf9H/7FiIiDZhdMA+M3j2f85vH/uV3l3JX54fkfErS1mteK7ee2/+e+A2sNZGCtgfddYzzDMFi9ejUrVqygf//+jnZvb2+mTp2K279Tuc6ePRubzcbUqVMd//BPnz6dLFmysHbtWp544gkmTpzIsGHDaNeuHQBTpkxhxYoVdz33oUOH+Pbbb1m5ciWNGzcGoPBtMx8FBAQAkDNnTrL8e2NudHQ0H3zwAatWraJWrVqOfTZs2MCXX35J/fr1mTx5MkWKFGHcuHEAlChRgj179vDRRx/d87147bXXqF27Nq1bt07We3f9+nVGjx6Nj48P1atXT9Y+d9O5c2eGDRvGyZMnAdi4cSPz589n7dq1jm0iIiKYPHkyM2bMoHnz5gD873//Y+XKlXz99dcMGTIkWdc+ZswYOnXq5OhRLFasGJMmTXK8dx4eHg90LSIikrSImAg++P0D+lbvSx7fPI7258s+T9MiTcnmlS3pHTdtgo8+gh9+oEGlZzGZ5hM/UCTW5EZNv31EmOzP0bLF2sPXv78DFBEnUchKA2HRYZy5ceY/t7v9eRfxLkVeSta+YdFh91VbvGXLluHj40NsbCw2m42OHTsyYsQIx/py5co5AhbArl27OHLkSKL7qaKiojh69CihoaGcO3eOGjVqONa5uLhQtWrVREMG4+3cuROLxUL9+vWTXfeRI0eIjIykSZMmCdpjYmIcQ+v279+foA7AEcju5ocffmDNmjUJJrG4m9q1a2M2m4mIiKBw4cIsWLCAXLlyJfsakpIjRw5atmzJjBkzMAyDli1bkj179gTbHD16lNjYWOrUqeNoc3V1pXr16uzfvx9I3rXv2rWL3bt3M2fOHEebYRjYbDaOHz9OKQ0tERFJdWuOr6H70u6cDD3JkWtHWPD0Asc6k8mUdMDatMl+A9bKlY6mYrsWUtLjAw5EF8bFxR6o4gOWYUB0tD1g/fu7SxFxEoWsNODn7kde37z/uV0OrxxJtiVnXz93v/uqLV7Dhg2ZPHkybm5u5MmTBxeXhD8K3t7eCZbDw8OpUqVKgg/mjppzJL6O5PC8j1+zhYeHA/DTTz+RN2/C98nd3f2+6gBYs2YNR48edfSYxWvfvj1169ZN0KO0YMECSpcuTbZs2RJt/yC6d+/uGLIXEhKSase9U3h4OL1792bAgAGJ1mmiDRGR1BUVF8Wbq99kwh8THG1LDyzl+LXjFMpaKOmdkghXAOTLh/HqaxT7JQcH10FEBHh42O/PstnsMw2aTFCnDpQsmXbXJCL/TSErDTzIUL47hw+mFW9vb4oWLZrs7StXrsyCBQvImTMnfn5JB7zcuXOzZcsW6tWrB0BcXBzbtm2jcuXKSW5frlw5bDYb69atcwwXvF18T5rVanW0lS5dGnd3d06dOnXXHrBSpUo5JvGI98cff9zz+t544w169OiRqL4JEybw1FNPJWgPCgqiSJEi9zze/Yi/v81kMtG0adNE64sUKYKbmxsbN26kQIECAMTGxrJ161bH0L/kXHvlypXZt29fiv78RUQk5Xae30nnRZ3Ze2mvo61BwQZ8+eSXSQesTZtg5Ej49deE7UWKwFtvQadOmN3cGN4ITvW0PwIrJsYesOInwihVCj74wL4sIs6jkCXJ0qlTJ8aOHUvr1q0ZNWoU+fLl4+TJkyxatIihQ4eSL18+XnnlFT788EOKFStGyZIlGT9+/D2nNi9YsCDBwcF0796dSZMmUaFCBU6ePMnFixfp0KEDBQoUwGQysWzZMlq0aIGnpye+vr4MHjyY1157DZvNxmOPPUZoaCgbN27Ez8+P4OBgXnrpJcaNG8eQIUPo0aMH27ZtY8aMGfe8vsDAwCQnu8ifPz+FCt3lN413cenSJXbu3JmgLXfu3P85pNBisTiG/VkslkTrvb29efnllxkyZAgBAQHkz5+fjz/+mMjISF588UWAZF3766+/Ts2aNenXrx89evTA29ubffv2sXLlSj7//PMUXauIiCRmtVn5ZNMnDP9tOLG2WADcLe6MeXwMr9R8BbMpiQRks8GLL956eDBA4cIwfDh07gy3jTipVAn+9z+YPh02boTwcPDxgcceg27d7OtFxLn0ew5JFi8vL9avX0/+/Plp164dpUqV4sUXXyQqKsrRszVo0CC6dOlCcHAwtWrVwtfXl7Zt297zuJMnT+bpp5+mT58+lCxZkp49ezqmEs+bNy8jR47kjTfeIFeuXI6hdKNHj2b48OGMGTOGUqVK0axZM3766SdHGMqfPz/ff/89S5YsoUKFCkyZMoUPPvggDd+dhObOnUulSpUSfP3vf/9L1r5+fn537SkE+PDDD2nfvj1dunShcuXKHDlyhBUrVpA1a1Ygeddevnx51q1bx6FDh6hbty6VKlXinXfeIU+ePEmdUkREUuDE9RM0nNmQN1a/4QhYFXJV4K9ef/FardeSDlhg73p65x3768KFYdo0e+Dq1i1BwIpXqRJMnGh/MPHs2fbvEyYoYImkFybjbrMSCGFhYfj7+xMaGprog29UVBTHjx+nUKFCmo1NHin62RcRubuZO2fSbWk3AEyYGFpnKCMbjMTd5bb7hq9csY/pe/FFKF36VrvVCgsXQvv24Or6cAsXkf90r2xwJw0XFBEREUklXSt0ZenBpew4v4Nv2nxD3QJ1b628eRM++8wesEJD4cgRWLr01nqLBZ577uEXLSKpTiFLRERE5D5FxETg7XZrRl6TycTUVlNxMbvcmgnYMODbb2HIEDh9+tbOK1fal4MSP9JFRDI23ZMlIiIich/WHF9D0c+K8suRXxK0B3gG3ApYf/8NjRrZe6jiA5bZDN27w6FDClgimZRCloiIiEgK2AwbH274kCazmnA+/Dwdv+/IiesnEm50/Tq8+ipUrAi3PWuRZs1g1y74+mvIl++h1SwiD5eGCz4gzRsijxr9zIvIoyw0KpSuS7ryw8FbzySsnrc6vm6+CTd86inYsOHWcpEi9ukAn3zy4RQqIk6lnqz75PrvrD+RkZFOrkTk4Yr/mXfVzFci8og5du0YNb+u6QhYJky8W/9dfur4E9m8siXc+M037d89PeG99+zDBhWwRB4Z6sm6TxaLhSxZsnDx4kXA/hwpk8nk5KpE0o5hGERGRnLx4kWyZMmS5AOTRUQyqw0nN9F6XhuuRl8CIKtHVua0m0PzYs0hKgrCrkDOnLd2aN4cPv4Ynn0W8ud3UtUi4iwKWQ8gMDAQwBG0RB4FWbJkcfzsi4g8Cj5cNp+3/+qG1RQNgGd4SZ66vozA8CKwfj307AmFCsHPP8Ptv3AdMsRJFYuIsylkPQCTyUTu3LnJmTMnsbGxzi5HJM25urqqB0tEHilr/rjE21t6YnWxByyX043w+Pk7/rBZOPXty1Q6O8W+4aFDMHs2dOnixGpFJL1QyEoFFotFHzxFREQyGZsNpk7KgfuBuUS2ao1ld3dcfp1Mo9hf+DTmZfJy5tbGNWtC5crOK1ZE0hWFLBEREZEkHDoEv/0GcVefwv36n2S7VJTxMd15Nna2Y5sIkzfhwz4g16i+oF+4isi/Mv3sgsuWLaNEiRIUK1aMqVOnOrscERERScdOh55m0pZJAOzZA9eu2W+zevxiBH9EVEgQsH41NaWy69+srzhAAUtEEsjUPVlxcXEMHDiQ3377DX9/f6pUqULbtm3Jli3bf+8sIiIij5SDlw/SZFYTToedJtYai+u5QVitUNl1Nz9GNMSM/TmBYfjxutckZtGV6BgT5845uXARSXcydU/Wn3/+SZkyZcibNy8+Pj40b96cX3/91dlliYiISDqz/dx26k6vy+mw0wB8ue1LsuaMxGyGXbbyLHTtCMAGS30e89vNPNdg4qwmzGbQhKsicqd0HbLWr1/PU089RZ48eTCZTCxZsiTRNiEhIRQsWBAPDw9q1KjBn3/+6Vh39uxZ8ubN61jOmzcvZ86cSXQMEREReXStP7mehjMbcinS/gysCrkq8PsLv1OtohcBAWAY8Krlc4a4T6KV92pOGAWIibG3BwRA+fJOvgARSXfSdciKiIigQoUKhISEJLl+wYIFDBw4kHfffZft27dToUIFmjZtqudWiYiISLL8dOgnms5uSlh0GAB1cldn7bLs5Fq+juLFoWFD8PCAUFMWQsz9iYq1EBdnv0/LwwMaNYLixZ18ESKS7qTre7KaN29O8+bN77p+/Pjx9OzZkxdeeAGAKVOm8NNPPzFt2jTeeOMN8uTJk6Dn6syZM1SvXv2ux4uOjiY6OtqxHBYWlgpXISIiIunRvD3z6LqkK3G2OACaZavJ9x+cwuvkWdi0HXPt2gwZko9z5+DgQYiNtU/rbjaDqyuUKAGDB9uXRURul2H/WYiJiWHbtm00btzY0WY2m2ncuDGbN28GoHr16vz999+cOXOG8PBwfv75Z5o2bXrXY44ZMwZ/f3/HV1BQUJpfh4iIiDx8U/6aQqdFnRwB61mXiiwdtNUesMCeos6coVIlGD8ennnGHqry57d/79DB3l6pkhMvQkTSrXTdk3Uvly9fxmq1kitXrgTtuXLl4sCBAwC4uLgwbtw4GjZsiM1mY+jQofecWXDYsGEMHDjQsRwWFqagJSIiksmERoUyct1IjH9nC3zpckE+D9mJxfh3g3r1YN48yJMHsAepChXgyBEIDQV/fyhaVD1YInJ3GTZkJVerVq1o1apVsrZ1d3fH3d09jSsSERERZ/L38GdN1zU0/Lou3bbFMea7E5jiV77xBoweDS4JPyKZzbr3SkSSL8OGrOzZs2OxWLhw4UKC9gsXLhCouVRFRETkHkot2cDuj2+Q41qMPWBlzQqzZkHLls4uTUQygQzb0e3m5kaVKlVYvXq1o81ms7F69Wpq1arlxMpEREQkvVl1bBVWm9W+cP48DBpEzviAVb067NihgCUiqSZdh6zw8HB27tzJzp07ATh+/Dg7d+7k1KlTAAwcOJD//e9/zJw5k/379/Pyyy8TERHhmG1QRERE5Mu/vqTJrCYELwm2B63AQJg/3z4GsH9/+P13KFDA2WWKSCZiMgzD+O/NnGPt2rU0bNgwUXtwcDAzZswA4PPPP2fs2LGcP3+eihUrMmnSJGrUqPFA5w0JCSEkJASr1cqhQ4cIDQ3Fz8/vgY4pIiIiD99X276i97LejuX57efzbNln7Qt790KZMk6qTEQymrCwMPz9/ZOVDdJ1yHK2lLyRIiIikr5M3T6Vnj/2dCwPrT2EDxt/hMlkusdeIiJJS0k2SNfDBUVERETux7w98+j1Yy/H8pCN8OHePApYIvJQZNjZBUVERESS8tOhn+i6pKvjOViDNsFHK8GUbQsYBihoiUgaU0+WiIiIZBq/n/ydp799mjhbHAC9/4Kxv4Jp5EiYO1cBS0QeCvVkiYiISKaw8/xOnpzTkihrFADP/g0hq90xLZwNTz/t5OpE5FGiniwRERHJFALPhlHwgj1gNTsM36zNimX1bwpYIvLQqScrCbdP4S4iIiIZwNatBDZtw7qbsbzbAMYczo/bhl+hRAlnVyYijyBN4X4PmsJdREQkgzh/HmrXhuPHoVIlWL7c/tBhEZFUoincRUREJNO7EX2D/sv7ExYdZg9Uv/wCzz0H69YpYImIU2m4oIiIiGQ4sdZYnvn2aVYc+5U/zvzBz51+Jnvx4jBvnrNLExFRyBIREZGMxbDZ6DOyGissuwA4cvUIlyIukd0ru5MrExGx03BBERERyTgMg/eH1WHqvwHLzWZm6bNLKJWjlJMLExG5RSFLREREMgarlW9ebchwrz8cTTP9g6lXsL4TixIRSUwhS0RERNK/uDhWv9SUF/3XOZo+yvIMzw2c5sSiRESSppCVhJCQEEqXLk21atWcXYqIiIjExLAnuDntsq8mzmJv6pPlCYYMWODcukRE7kLPyboHPSdLRETk4YuLg9Wr7Y++yhMQRampLalVZA3/+NvXP+VXjUWvbMLFrPm7ROThSUk20L9OIiIikm7MmwcffQQnT4IpJpr5Me0JMK2hajv4xx+qeRdnXt/fFLBEJF3TcEERERFJF+bNgwEDYN8+iIoCF2s0vtbreMXCzG+96Gp7gR9fWo+3m7ezSxURuSeFLBEREXG6uDgYMQKuXweLBVxdIcbDj/bev/CLuTltzMvZsmAa2TxyObtUEZH/pJAlIiIiTrdyJZw6BWYzuLuDtfgSDL9T3HTx5Tnf5Wy01OfkSft2IiLpnUKWiIiION3u3RAXY+NtRuOd+0ciW3TgxnPVicu9GZMJ3NwgNta+nYhIeqeQJSIiIk7n6WEQYvShi9c73HyqLVhiMbwvEFvsWwAMA0wm8PR0cqEiIsmgqXmSEBISQkhICFar1dmliIiIZH6GQaetr+Dm+iW1n4dr3vb/f11ONsHj97EYBkRH2wNW48ZOrlVEJBn0nKx70HOyREREHoLhw7G+/x5tnoNlJexNpqvF8Zn3B8bNrERF2XuxHn8cfvrJft+WiMjDpudkiYiISMbw2Wfw3nsMa3IrYHEzKy4LlnHzWlbHRBilSsEHHyhgiUjGoJAlIiIizvHvg7FmlYexdexNFpOFp2K+41TeYoT7g48PPPYYdOsGlSo5tVoRkWRTyBIREZGH79dfITiYbbmh11O3mj9r/hm9qzTiyBEIDQV/fyhaVD1YIpKxKGSJiIjIw7VvH7RrB7GxrCwCUa725t5VevNytZcBKF7cifWJiDwg/V5IREREHq5ixeDppwF4I0db5rSZRePCjfm02adOLkxEJHVodsF70OyCIiIiacQw4Msv7TdbeXhgGAYmk8nZVYmI3FVKsoF6skREROShuhF9wz4n+0svgYcHgAKWiGQqClkiIiKStqKjITgYDhxgx7kdFPy0ILN3z3Z2VSIiaUYTX4iIiEjaMQzo2RNmzeLyr0to+4onV6Ov0mVxF9wsbnQo08HZFYqIpDr1ZCUhJCSE0qVLU61aNWeXIiIikrGNHg2zZhFnhueahXMy+gIANfLWoHWJ1k4uTkQkbWjii3vQxBciIiIPYPZs6NIFgNebwMf/PnA4l3cutvXaRl6/vE4sTkQkZTTxhYiIiDjX+vXw4osALC1xK2C5mF34rsN3ClgikqkpZImIiEjqOnwY2raFmBiOZoXgZ90cqz5p8gmP5X/MicWJiKQ9hSwRERFJPVeuQIsWcPUqN13g6R6+hJpjAHim9DMMqDHAyQWKiKQ9hSwRERFJHbGx0KYNHDkCwGsdA9jpfQOA4tmKM7XVVD0PS0QeCQpZIiIikjpcXKB1a/uDhgMD6dh3CoE+gXi6ePJ9h+/xc9ckUiLyaNBzskRERCR1mEwweDAULgwFClCvShV2lK7LrvO7KJuzrLOrExF5aBSyREREJHW1a+d4GegTSGDRQCcWIyLy8Gm4oIiIiNy/w4dh9WoADMNg4d6F2Aybk4sSEXEuhSwRERG5P2Fh9nuwmjaFSZOYsHk8Hb7rQKt5rbh686qzqxMRcRqFLBEREUk5mw06d4b9+8FqZcvCCby++g0Afjr8E1vPbHVygSIizqOQlYSQkBBKly5NtWrVnF2KiIhI+vTuu/DjjwBcy+XHs61jibPFAfBGnTdoWrSpM6sTEXEqk2EYhrOLSK/CwsLw9/cnNDQUPz9NOysiIgLAwoXQoQMAhtlE+4m1WXx1IwB1guqwtttaXMyaW0tEMpeUZAP1ZImIiEjy7dwJ3bo5Fj//oI0jYAV4BjCv/TwFLBF55ClkiYiISPJcvQpt20JkJADberRkcOxPjtUz28wkyD/IWdWJiKQbClkiIiLy32w26NIFTpwAIKxWZZ4tu58YawwAg2oN4sniTzqxQBGR9EMhS0RERP7b3r3w22/219myMXJgFY5ePwZA9bzV+eDxD5xYnIhI+qKQJSIiIv+tXDnYsgVKloR58xjx1Dg6leuEv7s/C55egJvFzdkVioikG5pd8B40u6CIiMgd4uLAxT6xhWEYnA47TX7//E4uSkQk7Wl2QREREXlwNlviNpdbMweaTCYFLBGRJChkiYiISNL69YP+/SHGPrnF+M3jOXn9pJOLEhFJ/xSyREREJLFZs2DyZPj8c2jWjG//XsCgXwdR8cuKLN6/2NnViYikawpZIiIiktCePdC7t2PxxHPN6LXMvnw96jph0WHOqkxEJENQyBIREZFbbtyAp5+GmzcBiOvRnY6WJYRGhwLwfNnn6VqhqzMrFBFJ9xSyRERExM4w4OWX4dAh+3KlSozqkIvN/2wGoFCWQkxuORmTyeTEIkVE0j+X/95EREREMqu4OFi9Gs6fhyq7plN2zhz7Cl9f1n42iPdWdQHAxezCvPbz8Pfwd2K1IiIZg0KWiIjII2rePPjoIzh5EopG72XdzX6OdVemTKDzltcxsD9Oc1SDUdTIV8NZpYqIZCgKWSIiIo+gefNgwAAIDQUfcyQzYzrghf0+rOkevfji7DLORJwBoFGhRgytM9SZ5YqIZCgKWUkICQkhJCQEq9Xq7FJERERSXVwcjBgB16/bny0cYAnjRpw/WGGPqRx9AztwM6IxANk8szGr7SwsZotTaxYRyUhMhmEYzi4ivQoLC8Pf35/Q0FD8/PycXY6IiEiq+PlnaNcObDbw9ASTCVyMWN6IGsF81y7sjimJUfxHPJ/rzuynp/FUiaecXbKIiNOlJBuoJ0tEROQRs3s3xMbeClgAcSZX3vN8HwA34Ob+pxhkOcZTJXydV6iISAalKdxFREQeMZ6e4EEUPrakHypsGPbwlcVLAUtE5H4oZImIiDxiGjeGcebBrI+sQrm4HQDE5ltDdJmvsRkG0dH2INa4sZMLFRHJoDRcUERE5BFT8uBSSseGALA0vBGlsu0gtFkXDJ+zROVbjuXHb6hTx5uSJZ1cqIhIBqWeLBERkUfJ2bOYe77oWHzHbQwXmwzC8DkLgMkzjAqlPfngAzDrU4KIyH1RT5aIiMijwmaD4GC4cgWA6w3bsr+yK4bvIgAsMQEE+8+k31dmKlVyZqEiIhmbQpaIiMijYvx4WLXK/jpPHi797w3+WNAIYu1NnzaayssN86gHS0TkASlkiYiIPAq2b4c337S/NpmInTmdTmv6EREbAUDPyj3p+3hbJxYoIpJ56HdVIiIimV1EBHTsaH84FsCQIYw0r2fr2a0AFAsoxoSmE5xYoIhI5qKeLBERkcxu4EA4eND+ukoVNvZuzpjZjwPgYnZhTrs5eLt5O7FAEZHMRSFLREQkMzMMKFYMXF3tX3Pn8sa6F7EZNgBGNhhJtbzVnFykiEjmYjIMw3B2EelVWFgY/v7+hIaG4ufn5+xyRERE7t+2bXD8ODz9NFcir9B7WW/Oh59nXbd1WMwWZ1cnIpLupSQbKGTdg0KWiIhkVoZhEB4Tjq+7r7NLERHJEFKSDTTxhYiISGZ0+fI9V5tMJgUsEZE0opAlIiKS2fz9NxQsCO+8A7GxGIbB++vf50L4BWdXJiLySFDIEhERyUxiYqBzZ/u07aNHw6RJ/G/7/3j7t7cpO7ksyw8vd3aFIiKZnmYXFBERyUxGjIBdu+yvy5Th8PNNeW1GDQAuR15Gt2KLiKQ99WSJiIhkFhs3wkcf2V+7uhI3czpdlvcgMjYSgN5VetOyeEsnFigi8mhQyBIREckMbtyArl3BZn/+FSNH8kH4z2w5swWAogFFGffEOCcWKCLy6NBwQRERkcxg4EA4dsz+unZt/urciFHT6wBgMVmY3XY23m7eTixQROTRoZAlIiKS0f34I0ydan/t7c3NaV/R5YensRpWAN6q+xY18tVwYoEiIo8WDRdMQkhICKVLl6ZatWrOLkVEROTeLl2CHj1uLU+YwJvHp3Lg8gEAquapytv13nZScSIijyaFrCT07duXffv2sXXrVmeXIiIicm/Xr0NgoP31k0/yd6uaTNwyEQB3izvftPkGV4ur08oTEXkUKWSJiIhkZMWKwZ9/wrvvwtSplM1Vjnnt55HVIysfNv6QUjlKObtCEZFHjsnQAzPuKiwsDH9/f0JDQ/Hz83N2OSIiIsl2IfwCObxzYDbp96kiIqkhJdlA//KKiIhkNIYBsbH33CSXTy4FLBERJ9G/viIiIhnN1KlQsyb8/TcAFyMusmj/IicXJSIi8RSyREREMpITJ+zPxNq+HapUwTh+nF4/9qL9t+3pvKgz16OuO7tCEZFHnkKWiIhIRmGzQffuEB5uX+7cmW9C17P04FIAfj36KzHWGCcWKCIioIcRi4iIZBxffAG//WZ/HRTEqRGvMWBOHcfqL5/8kpzeOZ1UnIiIxFNPloiISEZw5Ai8/rpj0fb1VF747RXCosMACK4QTNtSbZ1VnYiI3EYhS0REJL2zWqFbN4iMtC+//DKT/Q+z5vgaAPL55WNis4lOK09ERBLScEEREZH07tNPYeNG++vChTk8rBdDZ90aJji99XSyeGRxTm0iIpKIerJERETSswMH4K237K9NJqzTptJtZV8iY+29Wn2q9qFx4cZOLFBERO6kkCUiIpKerV0LMf/OGPjKK0xy28mm05sAKJK1CB81+ch5tYmISJIUskRERNKzl16yDxV86il4/32eLfssLYq1wISJGW1m4OPm4+wKRUTkDibDMAxnF5FehYWF4e/vT2hoKH5+fs4uR0REBADDMNh6divV81Z3dikiIo+MlGQD9WSJiIhkMCaTSQFLRCQdU8gSERFJb778Ej75xD51O3DoyiGu3bzm5KJERCS5FLJERETSk2PHYOBAGDIE6tYlKiKUdgvaUXZyWX458ouzqxMRkWRQyBIREUkvbDZ48cVbDx2uWJERm8ew99Jezt44y5ur38Rqszq3RhER+U96GLGIiEh68eWX9inbAQoU4I9X2jN2wRMAuFncmNlmJhazxXn1iYhIsqgnS0REJD04eRKGDnUs3vwyhOCVfbAZNgBGNhhJuVzlnFWdiIikgEKWiIiIsxkG9OwJ4eH25Z49eYvVHLpyCIDqeaszuPZgJxYoIiIpoeGCIiIizjZtGqxcaX+dLx+/v9qWiQtbAuDh4sHMNjNxMeu/bBGRjEI9WSIiIs509iwMGuRYjJg8iRdW9cfAAOD9Ru9TMntJZ1UnIiL3QSFLRETEmUaPhtBQ++vgYN4wr+HotaMA1Amqwys1XnFicSIicj809kBERMSZxo4Fd3f49lsYP54KJxbh4+aD1WZlRpsZmk1QRCQDMhmGYTzIAaxWK3v27KFAgQJkzZo1tepKF8LCwvD39yc0NBQ/Pz9nlyMiIhmczQZHjtg7rvz9oWhRMMePKQkLg3//rzlx/QQ7z++kTck2TqtVREQSSkk2SHFP1quvvkq5cuV48cUXsVqt1K9fn02bNuHl5cWyZcto0KDB/dYtIiKSae3YATNnwv79EBUFHh5QqhQEB0OlSjgCFkDBLAUpmKWg02oVEZEHk+J7sr777jsqVKgAwI8//sjx48c5cOAAr732Gm+99VaqFygiIpLR7dgBo0bBX3+BqyvUsG0mX+wx/vrL3r7+z1BnlygiIqkoxSHr8uXLBAYGArB8+XKeeeYZihcvTvfu3dmzZ0+qFygiIpKR2Wz2HqwTJ+D6dTjwZxgDNj3LZ7+V46kjEzh2+hpP/lSO3j++xI3oG84uV0REUkGKQ1auXLnYt28fVquVX375hSZNmgAQGRmJxaKbc0VERG535Ahs2QJnzsDx4zDk6jDy2U7jRSTVLi3nUJFB3DCf5qvtX9L/5/7OLldERFJBiu/JeuGFF+jQoQO5c+fGZDLRuHFjALZs2ULJknqOh4iIyO2uXYOjR+2TXdTld3pbvwAgAi+CSz5PVOkXAfCy+DKq4ShnlioiIqkkxT1ZI0aMYOrUqfTq1YuNGzfi7u4OgMVi4Y033kj1AlND27ZtyZo1K08//bSzSxERkUfM1atw4wZ4GDeZEveio/2tLG9zpsVwx3KPoPHk98/vjBJFRCSV3ddzsuLDSlRUlKMtODg4dSpKA6+88grdu3dn5syZzi5FREQeMTdu2O/Lets2iqK2wwD8aanF5CYHMHzOAmA62pTaJV+812FERCQDSXFPltVqZfTo0eTNmxcfHx+OHTsGwPDhw/n6669TvcDU0KBBA3x9fZ1dhoiIPILMZqhi2clr1rEARONG5zKdiSnzjX2DaD88V/0Pi8XkxCpFRCQ1pThkvf/++8yYMYOPP/4YNzc3R3vZsmWZOnVqigtYv349Tz31FHny5MFkMrFkyZJE24SEhFCwYEE8PDyoUaMGf/75Z4rPIyIi4gxlS8YxxdoDF6wAjPAdxOEm7znWe66bQHbXIMqWdVaFIiKS2lIcsr755hu++uorOnXqlGA2wQoVKnDgwIEUFxAREUGFChUICQlJcv2CBQsYOHAg7777Ltu3b6dChQo0bdqUixcvOrapWLEiZcuWTfR19uzZFNcjIiKSmor/8inlY7YBcMBShs9bnQLfcwC4nWyOx4EXeOwxKF7cmVWKiEhqSvE9WWfOnKFo0aKJ2m02G7GxsSkuoHnz5jRv3vyu68ePH0/Pnj154YUXAJgyZQo//fQT06ZNc0y0sXPnzhSfNynR0dFER0c7lsPCwlLluCIi8ugyly9HdO4CuJ47xcDsnxPt/S4Apmh/sm74ilLlTQwebB9WKCIimUOK/0kvXbo0v//+e6L27777jkqVKqVKUfFiYmLYtm2bY5p4ALPZTOPGjdm8eXOqngtgzJgx+Pv7O76CgoJS/RwiIvKIeeIJ3A/9zYmx31Hs2QZU2/sbeXd/StFDITzXIh/jx0Mq//cpIiJOluKerHfeeYfg4GDOnDmDzWZj0aJFHDx4kG+++YZly5alanGXL1/GarWSK1euBO25cuVK0dDExo0bs2vXLiIiIsiXLx8LFy6kVq1aibYbNmwYAwcOdCyHhYUpaImIyIPz8aHw4HZMsMGRI2ZCQwfg7w9Fi6oHS0QkM0pxyGrdujU//vgjo0aNwtvbm3feeYfKlSvz448/0qRJk7So8YGtWrUqWdu5u7s7nvslIiJy3yIjwdMTTAlnDDSbde+ViMij4L6ek1W3bl1WrlyZ2rUkkj17diwWCxcuXEjQfuHCBQIDA9P8/CIiIvele3f7U4i//JIrufxoPb81Hzz+AfUK1HN2ZSIi8hCk60EKbm5uVKlShdWrVzvabDYbq1evTnK4n4iIiNP9+CMsWAArV0KDBvT/qS8bT2+kwYwGTNsxzdnViYjIQ5Diniyz2YzJdPcHJlqt1hQdLzw8nCNHjjiWjx8/zs6dOwkICCB//vwMHDiQ4OBgqlatSvXq1Zk4cSIRERGO2QZFRETSjbAw6NPHsbh4WBvm7ZsEQBaPLDQvevfZdEVEJPNIcchavHhxguXY2Fh27NjBzJkzGTlyZIoL+Ouvv2jYsKFjOX7iieDgYGbMmMGzzz7LpUuXeOeddzh//jwVK1bkl19+STQZRmoKCQkhJCQkxYFRREQecW++Cf/8A8DlFg14KXy+Y9Wk5pPI7ZvbWZWJiMhDZDIMw0iNA82dO5cFCxawdOnS1DhcuhAWFoa/vz+hoaH4+fk5uxwREUnPNm+GOnXAMMDLi+e/aMT8E/ZZd1uVaMWSZ5fccySIiIikbynJBql2T1bNmjUT3DslIiLyyIiJgZ497QELWPTOM46AldUjK1NaTlHAEhF5hKRKyLp58yaTJk0ib968qXE4ERGRjOXjj2HvXgAu16rAy5afHas0TFBE5NGT4nuysmbNmuC3cYZhcOPGDby8vJg9e3aqFiciIpLuHTwIo0fbX1ss9O8eyMUzuwD7MMFO5To5sTgREXGGFIesCRMmJAhZZrOZHDlyUKNGDbJmzZqqxYmIiKR7S5bYhwsCRwe9wOLzswANExQReZSl2sQXmZEmvhARkWT55RcYOxZ+/JEDkad4YekL9KvWj07l1YslIpJZpCQbJCtk7d69O9knL1++fLK3Ta9un8L90KFDClkiIpIiVpsVs+nez5UUEZGMJdVDVvwDiP9rU5PJlKmeLaWeLBERERERgZRlg2Tdk3X8+PFUKUxERCRT+PVXuHABOnfm8s0rfLblM9547A08XT2dXZmIiKQDuifrHtSTJSIiiYSHQ5kycOoUNG7M8y/6M//g95TMXpKFzyykbM6yzq5QRETSQKr3ZCVl3759nDp1iph/Z1SK16pVq/s9pIiISPo3fLg9YAGLsl1k/sFVAFwIv0A2z2zOrExERNKJFIesY8eO0bZtW/bs2ZPgPq34m3sz0z1ZIiIiCfz1F0yaBMDlAA9ernQGouyr9NBhERGJZ07pDq+88gqFChXi4sWLeHl5sXfvXtavX0/VqlVZu3ZtGpQoIiKSDsTFQc+eYLMB0P/VElyMugLoocMiIpJQikPW5s2bGTVqFNmzZ8dsNmM2m3nssccYM2YMAwYMSIsaH7qQkBBKly5NtWrVnF2KiIikFxMnws6dACxqVoD5tl2AHjosIiKJpThkWa1WfH19AciePTtnz54FoECBAhw8eDB1q3OSvn37sm/fPrZu3ersUkREJD04fhzefReAy17wcr0wxyoNExQRkTul+J6ssmXLsmvXLgoVKkSNGjX4+OOPcXNz46uvvqJw4cJpUaOIiIjzGAb06QORkQD0f6UYF2MOAxomKCIiSUtxyHr77beJiIgAYNSoUTz55JPUrVuXbNmysWDBglQvUERExKkWLIBffgFgRY1szHe3BywNExQRkbtJledkXb16laxZs2a6/2j0nCwREeHSJRg4EGbPJnbxd3wccICR60YyrfU0Opfv7OzqRETkIUlJNkhxyJo9ezZt27bF29v7gYrMCBSyRETEYccOqFQJgOPXjlMwS8FM98tFERG5u5RkgxRPfPHaa6+RK1cuOnbsyPLly/VcLBEReTT8G7AACmUtpIAlIiJ3leKQde7cOebPn4/JZKJDhw7kzp2bvn37smnTprSoT0RE5OGLjrYPEwQuR15m+7ntTi5IREQykhSHLBcXF5588knmzJnDxYsXmTBhAidOnKBhw4YUKVIkLWoUERF5uMaMgVKlYOZM+i3vR/X/VWf4muHEWGOcXZmIiGQAKQ5Zt/Py8qJp06Y0b96cYsWKceLEiVQqy7n0MGIRkUfY/v3wwQdw5Qrff9KdBXsXYDWshGwN4erNq86uTkREMoD7ClmRkZHMmTOHFi1akDdvXiZOnEjbtm3Zu3dvatfnFHoYsYjII8pmg969ITaWy17Qp72HY9VnzT8j0CfQicWJiEhGkeLnZD333HMsW7YMLy8vOnTowPDhw6lVq1Za1CYiIvJwTZsGv/8OQL8OPlw0hQPQukRrOpbr6MzKREQkA0lxyLJYLHz77bc0bdoUi8WSFjWJiIg8fBcuwJAhAHxfChYUtAesrB5ZmdxysmYTFBGRZEtxyJozZ05a1CEiIuJcr70G16/fNkwwCrAPE8ztm9u5tYmISIbyQBNfiIiIZAq//ALz5gHQr40bF13sAUvDBEVE5H4oZImIyKMtIgJefhn4d5hgcfs07QGeAUx5coqGCYqISIolO2SdPXs2LesQERFxjv374cYNAAoXqUK5nOUAzSYoIiL3L9khq0yZMsydOzctaxEREXn4qlaFAwege3cqfTKHv3r9xey2s3m+7PPOrkxERDKoZIes999/n969e/PMM89w9aoexigiIplI9uzw9ddQogRuFjc6le+kYYIiInLfkh2y+vTpw+7du7ly5QqlS5fmxx9/TMu6REREHorQqFBirbHOLkNERDKRFE3hXqhQIdasWcPnn39Ou3btKFWqFC4uCQ+xffv2VC3QGUJCQggJCcFqtTq7FBERSQv//AMjRsAHH9BjXV+OXTvGjNYzKJernLMrExGRTMBkGIaRkh1OnjzJCy+8wN9//03v3r0Thax33303VQt0prCwMPz9/QkNDcXPz8/Z5YiISGpp0waWLuXbGt482zwCgDy+eTg24BjuLu7OrU1ERNKllGSDFPVk/e9//2PQoEE0btyYvXv3kiNHjgcqVERE5KFbvBiWLuWCN/RpEOloHv/EeAUsERFJFckOWc2aNePPP//k888/p2vXrmlZk4iISNoIC4P+/TGAPi3hiqd9MEf7Uu3pUKaDc2sTEZFMI9khy2q1snv3bvLly5eW9YiIiKSdt96CM2dYUBYWlbY3ZffKzhctv9BsgiIikmqSHbJWrlyZlnWIiIikrS1bICSE8z7Qt+Wt5pAWIeT0zum8ukREJNNJ9hTuIiIiGVZsLPTsiWEYvPQkXPW0N3co00HDBEVEJNWlaOILERGRjMBmgyNHIDQU/P2h6KLxmPfsYU55WFrSvk1O75yEtAhxbqEiIpIpKWSJiEimsmMHzJgB27ZBRAQUcDnDtztH4gaczGLCjAkbNqa0nEJ2r+zOLldERDIhhSwREck0duyAgQPh0CF7b5ZhwHnyMMjnK0ZHvEbPvJ14/MXn+PHgj7Qt1dbZ5YqISCalkCUiIpmCzQZjx8Lu3eDiAu7uYDaDzWbiW6MzP9OcenHuTM3jQ818NZ1droiIZGIKWSIikikcOgQbN9rDVmysfaigzQYms4G7m4krZGP1Fvt2JUs6u1oREcnMNLtgEkJCQihdujTVqlVzdikiIpJMf/8N165BdDRERUEZ429c3Qxi2rblRvmPiYqxcu2afTsREZG0pJCVhL59+7Jv3z62bt3q7FJERCSZDANiYuy9V43Ma9kSWY6OxWsQV3QpcQ1fJ6bVs8TE2LcTERFJSwpZIiKSKfj4gMkEbrYoJtzszUl/mNP41i/LzLu6YzLZtxMREUlLuidLREQyhYAA8PWFV658QBHjEE1aww13+zrL7hcwH22Br799OxERkbSkniwREckUsmaFxrn3MsT2IZOrwprC9nZTWBBuaybg7w9Fiti3ExERSUvqyRIRkUyhaGEb713qxamAWIY2udXuv3YaefL44+YGNWtC0aLOq1FERB4NClkiIpIpmKd+RYHzm2jQDSLd7G0FL71MmdyNuX4dcuSArl3tz84SERFJSwpZIiKS8Z09C6+/zqc1YUMBe5NnVGHy7vuYWFeoVs0esCpVcm6ZIiLyaFDIEhGRjO+VV4gLD2NGRfuiCRP/azmd4u188Pe3DxFUD5aIiDwsClkiIpKx3bwJ4eG42OCPJdkZFtIOFy8fOj1Wz9mViYjII0ohS0REMjZPT1i+HObPx8vdnU/btsPQE4dFRMSJFLJERCTjM5ng+edvWzQ5sRgREXnUaYS6iIhkWDHWGHr92IsjV484uxQREREHhSwREcl4YmKgZUtGf92V/23/HxWmVGDB3wucXZWIiAig4YIiIpIRffwxf+5azpiqgNneo1UsWzFnVyUiIgKoJ0tERDKaAwe4OWYUXduC9d//xd6p9w6Vc1d2bl0iIiL/UsgSEZGMw2aDXr0YVi+Wg9ntTdXyVGNY3WHOrUtEROQ2CllJCAkJoXTp0lSrVs3ZpYiIyO2mTuW307/zaU37ooeLB9+0/QYXs0a/i4hI+mEy9DCRuwoLC8Pf35/Q0FD8/PycXY6IyKPt3DnCKpSkfKcwTmaxN01oOoFXa77qzKpEROQRkZJsoJ4sERHJGPr357VatwJWg4INGFBjgFNLEhERSYpCloiIpH9Ll7J3/fdM+3duC19XH6a3no7ZpP/GREQk/dH/TiIikr7ZbPD665S5BKtmQpBLNiY0m0jBLAWdXZmIiEiSdKewiIikb2YzrFgBL7/M44bBvsHf4u3m4+yqRERE7kohS0RE0r8CBeCnnyAiAh93BSwREUnfNFxQRETSrX/C/uGLrV9gM2xgMoGPApaIiKR/ClkiIpIu2X5YSvfvu9J3eV+azm7K+fDzzi5JREQkWTRcUERE0p9du/hiTDtWNrMBsO/SPtwsbk4uSkREJHnUkyUiIulLXBwHXunEkMdtjqYZrWcQ4BngxKJERESSTyFLRETSldgJ4+hSfC9RrvblfpVfpkmRJs4tSkREJAUUskREJP04epT3f32bv/LaF0t45eejZp84tyYREZEUUsgSEZH0wTD4c9BzvFc7DgCLYWJWx+/wcvVycmEiIiIpo5AlIiLpQuTXU+gS9BfWf/9nGl57GNXyVnNuUSIiIvdBIUtERJzv/Hk+/P41DmW3L1bzLs6bj49wakkiIiL3SyFLREScyzCgTx8G/xZNtx3gabMwq9sPuFpcnV2ZiIjIfVHIEhER52vUCD8Xb6ZvysH+bn9RInsJZ1ckIiJy3/QwYhERcS6TCfr1gyefhBMnKFCoorMrEhEReSDqyRIREadZfng5J6+ftC8ULAgNGjizHBERkVShkCUiIk5x7NQunv3uWcpPKc+c3XOcXY6IiEiqUcgSEZGHLu7qZbp8WJ3wmHDCosNYfXy1s0sSERFJNQpZIiLy0H34XlM25YoBoHCsL582+9TJFYmIiKQehawkhISEULp0aapV00MwRURS25+LPmOE73YAzDaY1XoGvu6+Tq5KREQk9ZgMwzCcXUR6FRYWhr+/P6Ghofj5+Tm7HBGRDC/i2gUqjc7HYf84AIZ7t2DU4J+cXJWIiMh/S0k2UE+WiIg8NIM+etwRsKqF+TL8lUVOrkhERCT1KWSJiMhD8ePij/jScy8AXjEwu/MiXF3dnVyViIhI6lPIEhGRNBd+/SIv/vmWY3mC3zMUr9TYiRWJiIikHYUsERFJcz4jxzDjeys5w6HVhaz0HDTX2SWJiIikGRdnFyAiIplcbCxs20aLw7B7mjuW35ZjctF/PyIiknnpfzkREUlbrq7w228waRK5XFygfE1nVyQiIpKmFLJERCRNRMREsPjAYjqV64TJYoHXXnN2SSIiIg+F7skSEZE0MXDFQLos7kLbBW25HHnZ2eWIiIg8NApZIiKS6hbvnMdX278CYOWxlVyJvOLkikRERB4ehSwREUlV/4T9Q4/F3R3LkzzbUSJ7CSdWJCIi8nApZImISKqx2qx0nd6Kq+YoANofMNO9xdtOrkpEROTh0sQXIiLyQGw2OHIEQkNhwfH3+e36DgDyhcJX1UZiKqFeLBERebQoZImIyH3bsQNmzIBt2+Ci22aO1h0BZjAZMPtwWQLGDnN2iSIiIg+dQpaIiNyXHTtg4EA4dAhuGteJfq4tNrMBwNANLuTovwgsFidXKSIi8vDpniwREUkxmw3GjrUHrWvXILrqUCL9LwBQ5xRYN33M+98Ww2ZzcqEiIiJOoJAlIiIpdugQ/PYb3LxpX5645gbP7IWsN6Hfotp8FvcKa9bYtxMREXnUaLigiIik2J499h4skwmKuRyjy43F9FgIf2fx4XnrPDCbuXbNvl3Jks6uVkRE5OFST5aIiKTYuXNgtYKLC5yyFKaB73Z2WSrzRcznnLHkx8XFvv7cOWdXKiIi8vCpJ0tERFIsMBCMGhOJPfg0LrH5OGgpTWOfLVixYBgQFwdms307ERGRR416skREJMVOZ5mPtclrxHSvyM18P2G1QhwuWG0mYmLAMCAgAMqXd3alIiIiD596skREJEWOXTvGyL962he8rmB4XSIu7tZ6kwk8PKBRIyhe3Dk1ioiIOJNCloiIJFt0XDTPffccN2LDAWiz15/zJ+pwxNs+rbvZDK6uUKIEDB5sXxYREXnUKGSJiEiyDVk5hK1ntwJQ9ApM/cOHj9vlxPI3RESAtzdUrQrBwVCpkpOLFRERcRKFLBERSZbv9n3HZ39+BoB7HCxcCNnmfMOYBv4cOQKhoeDvD0WLqgdLREQebQpZIiLyn45cPUL3pd0dy5/+DBU7DIBGjTCje69ERERup981iojIPUXFRfHMwme4EXMDgI67oVdUafjwQydXJiIikj6pJ0tERO5p2aFl7Dy/E4ASl+HLFa6YNs0DT0/nFiYiIpJOqSdLRETu6elcDfluZVYCb8DCb8Fn1Id6AJaIiMg9qCdLRETubcIE2m+8Rsst4NGgMbz6qrMrEhERSdcUskRE5N5GjAAXFzwmT4aZMzV1oIiIyH/Q/5QiIpJIv+X9mL5jun3BxcUetA4fhjx5nFqXiIhIRpDpQ9bp06dp0KABpUuXpnz58ixcuNDZJYmIpGv/2/Y/QraG0P2H7vT9qe+tFX5+zitKREQkA8n0wwVdXFyYOHEiFStW5Pz581SpUoUWLVrg7e3t7NJERNKdrWe20u/nfo7lOvnrOLEaERGRjCnTh6zcuXOTO3duAAIDA8mePTtXr15VyBIRucPlyMu0/7Y9MdYYAPr/aaKj5z9QzsmFiYiIZDBOHy64fv16nnrqKfLkyYPJZGLJkiWJtgkJCaFgwYJ4eHhQo0YN/vzzz/s617Zt27BarQQFBT1g1SIimYvVZuX575/ndNhpAOqcgk9WGBAT4+TKREREMh6nh6yIiAgqVKhASEhIkusXLFjAwIEDeffdd9m+fTsVKlSgadOmXLx40bFNxYoVKVu2bKKvs2fPOra5evUqXbt25auvvkrzaxIRyWiG/zacVcdWAZArHL5dCG71G8GwYU6uTEREJOMxGYZhOLuIeCaTicWLF9OmTRtHW40aNahWrRqff/45ADabjaCgIPr3788bb7yRrONGR0fTpEkTevbsSZcuXe65XXR0tGM5LCyMoKAgQkND8dMN3yKSSS05sIS2C9oCYLHBmplQLzIH7NoF/w63FhERedSFhYXh7++frGzg9J6se4mJiWHbtm00btzY0WY2m2ncuDGbN29O1jEMw6Bbt240atTongELYMyYMfj7+zu+NKxQRDK7Q1cOEbwk2LE89leodxL45hsFLBERkfuUrkPW5cuXsVqt5MqVK0F7rly5OH/+fLKOsXHjRhYsWMCSJUuoWLEiFStWZM+ePUluO2zYMEJDQx1fp0+ffuBrEBFJz8JjwvFz9QWgw9/w6h/AkCHQrJlzCxMREcnAMv3sgo899hg2my1Z27q7u+Pu7p7GFYmIpB+VAyuxbWd1hl9fzLhfwVSjBrz/vrPLEhERydDSdcjKnj07FouFCxcuJGi/cOECgYGBTqpKRCQTOXiQnN/+xJcxgL8/zJsHrq7OrkpERCRDS9fDBd3c3KhSpQqrV692tNlsNlavXk2tWrWcWJmISMa19+Je4mxx9oWSJWHLFihRAqZOhUKFnFuciIhIJuD0nqzw8HCOHDniWD5+/Dg7d+4kICCA/PnzM3DgQIKDg6latSrVq1dn4sSJRERE8MILLzixahGRjOng5YPUmVaHanmrseDpBQR4BkDFirB7N7i5Obs8ERGRTMHpIeuvv/6iYcOGjuWBAwcCEBwczIwZM3j22We5dOkS77zzDufPn6dixYr88ssviSbDSE0hISGEhIRgtVrT7BwiIg9baFQoree3JjQ6lFXHVjFi7QgmNZ9kX6mAJSIikmrS1XOy0puUzIUvIpKeWW1WWs1vxfLDywEoa83G5tcP4+Od1cmViYiIZAyZ5jlZIiKSOt5a85YjYAVEwtLPr+DT9CmIinJyZSIiIpmPQpaISCY3b888Ptr4EQAWGyxcCIWvAVWqgIeHc4sTERHJhBSyREQysW1nt9H9h+6O5Qm/QKPjQK1aMHas8woTERHJxBSyREQyqXM3ztFmQRui4uxDAl/cDv3+BLJnh2+/1WQXIiIiaUQhS0Qkk3r/9/f5J+wfAGqfgpCfwGQ2w/z5kC+fk6sTERHJvBSykhASEkLp0qWpVq2as0sREblv454YR+cibckfZub7b8HdCowaBY8/7uzSREREMjVN4X4PmsJdRDK06GiM+vW4sPdPAsOBli3hhx/ArN+viYiIpJSmcBcReUTF2eJuLUREYHJ1swesggVh1iwFLBERkYdA/9uKiGQSq46touwXZTlw+YC9ISAAVq+Gvn3h++8hqx48LCIi8jBouOA9aLigiGQU+y7to/bXtQmNDiWLRxb+ePEPSmQv4eyyREREMg0NFxQReYRcjLhIy7ktCY0OBaBe7poUDSjq5KpEREQeXQpZIiIZ2M3Ym7Se35oT108AUOmaB3M+OIhl/wHnFiYiIvIIU8hKgqZwF5GMIM4Wx/PfP88f//wBQN4YD36cFoXPwePQrRtoNLiIiIhT6J6se9A9WSKSXhmGQe9lvfnf9v8B4GO48fuXMVQ8D/j7w59/QvHizi1SREQkE0lJNnB5SDWJiEgqsNngyBEYu3UEU4/YA5aryYXF3/wbsMxmmD9fAUtERMSJFLJERDKIHTtg5kzYfHozf5Yf5WifsdRC42P/Ph/rww+hWTMnVSgiIiKge7JERDKEHTtg1Cj46y/IEV2L0v98AsDolX503B5t36hzZxg82IlVioiICKgnS0Qk3bPZ7D1YJ05AbKx9uKBnTA++85pM+zNHATieuxYFpnyF2WRybrEiIiKiniwRkfTuyBH44884zpyB48chLAxahc+9FbDMReiTZylHzng6uVIREREBhSwRkXRv75kT/FWjNNeyL8cwwMUFZnq+xJvun3CRHDxp+Zltp3Jw7ZqzKxURERFQyBIRSdfOhJ2hz5ZGWLMcJu6ZVphK/oDFAiazicmeg6jmd4gjpmLcuAFXrzq7WhEREQGFrCTpYcQikh5cCL/A4988zvno4wBYrhbBcrZ2gm1CTVkwmez3bd244YwqRURE5E4KWUno27cv+/btY+vWrc4uRUQeUVcir9BkVhMOXjkIgNe1POyaeYHHr/2J1QqGAVYrxMSAxQJubvZHZImIiIjz6b9kEZF0JjQqlKazm7Ln4h4AcrsG8sfMG5S5Ecp3MU9RM2Y9MTH2kOXhYQ9YAQFQtqyTCxcRERFAU7iLiKQr4THhtJjbgm3ntgGQ2zMn676Oo9h1+1jANW7NOZyjNjnM9t6s6Gj+396dx0dV3nsc/5yZyb6zhyWyBglLEjY3QIIgShVRoF6kiFStF1HsRaVX24Kl7a163Uobr0tVRBEoVsEigrILMYAkARHCJrKGHbKHJDPn/nFgkkBYnWRmyPf9es1rZs55zplfJnleM9885zyH8nLo1Qvi471ZuYiIiJyhkCUi4iOKy4oZPHMwaXvTAGgYXJ8lMxy023YAgC0RPXg0bBYl5Q5MEwzDmmkwIcG6BrEOFxQREfENClkiIj5ifc56Vu9dDUB0UBRfzY2gw8YfrZWdOlE29QsGzQ1n/XooLISwMOjeHUaPhuRk79UtIiIiVRmmaZreLsJX5eXlERUVRW5uLpGRkd4uR0TqgIU7FvLAp6P5bGEMPZdak17QujWsWgWxsbhc1sWJc3MhKgrattUIloiISG24nGygkSwRER9yW9M+/PB5W0JXWIcM0qwZLF4MsbGAFah07pWIiIhv0/8/RUS8JP9UPtOyplVduG4doWmnLx9Rvz589RW0alXrtYmIiMiVU8gSEfGCkyUnufXDWxkzbwwvrn6xYsXNN8Nnn0GTJrBoEXTo4L0iRURE5IooZImI1LJjRce4ZfotpO9LB+CF1S9wpPBIRYPbboOdO6FbNy9VKCIiIj+FQlY1UlNTSUhIoEePHt4uRUSuMocKDpHyfgoZORkANAxtyLLmv6NhWMOqDUNDvVCdiIiIeIJmF7wAzS4oIp50IP8At0y/heyj2QDEhseyJKMTHT76Cl54ASZO9HKFIiIicj6Xkw00kiUiUgu2HNnCDe/c4A5YLSKbs3JNBytgAUyaBD/+6L0CRURExGM0hbuISA1bvWc1d868kxMlJwBoFdWSpcuvoeW8pVaD4GCYOxdatvRajSIiIuI5ClkiIjXI6XLy8L8fdgespEZdWDA/mtgFK6wGoaHw739Dv35erFJEREQ8SYcLiojUILvNzif3fkK9kHr0vyaFFZ9EEbtgpbUyLAy++EIBS0RE5CqjkCUiUsOubXAtq+76jM/fLCBy8dfWwogI+PJL6NPHu8WJiIiIxylkiYh4UJmzjJfTXqbUWVpleYcn/khg+jrrSVQULF4MN97ohQpFRESkpilkiYh4yPHi4wz6aBBPffUUv5z3S1ymq2Ll1KlQvz40awYrV0LPnt4rVERERGqUQpaIiAd8f/h7erzdg8U/LAbg480f892h7yoaxMfDwoXwzTfQpYuXqhQREZHaoNkFRUR+ornZcxn16SgKSgsAaBTWiE9i/4vEmGurNuze3QvViYiISG3TSJaIyBVymS6mrJjC3bPvdgesrrFdWZf3H9z0i2fggQfA5brwTkREROSqo5BVjdTUVBISEujRo4e3SxERH1VQWsDP5/ycycsnu5eN6DCcr1fFE/fHqdaCWbPg88+9VKGIiIh4i2GapuntInxVXl4eUVFR5ObmEhkZ6e1yRMRHHC48zIAPBrDx0EYADAz+0nUiEycvwsjMshoZBrzyCvz6116rU0RERDzncrKBzskSEblM9ULq0SS8CRsPbSQyKJKZrScyaMyrcOyY1SAsDKZPh3vu8W6hIiIi4hU6XFBE5DI5bA5mDZ3Fz9r9jDXGrxg0YlJFwGrbFtLTFbBERETqMI1kiYich8sFO3ZA1v4tOAOPc+8NN2E7/a+pGCOE+fPC4J8vVWzws5/Bhx9CdLRX6hURERHfoJAlIlKNzEx4b5rJFznT+KH9Y9idkSyds4FHRzciORkIDITi4ooNJk2CyZNxpzARERGps/RtQETkLJmZMP7pPN4+9gt2dPwlLkcRZUEH+ejAH5gwwVqPzQYffGBd+2rePPjDHxSwREREBNBIlohIFS4XPJm6lNWdH8KM3uVeHpY1iq5fDiXDAS+9ZOUrW1QUrFmjcCUiIiJV6JuBiMhpeafyuO+j/2RZi1sqAtapSHrMe5bt8xbzadFwYooPsHQpbNt2eiMFLBERETmLvh2IiACLdiyi0+udmL3zTfeygH29+OM7Q1ib+T/EmjnU5zgvOidw/Dhs3OjFYkVERMSn6XBBEanz8k/lc98n93G8+Li1oDSMVssfY376PBJcq9ztFjsG8kzAq7jK4OBBLxUrIiIiPk8jWSJS50UERfDawNcA6BKcwu/f+A+2pb1EgisbgGKCmRjyN4aHfcF+Vyx2O8TGerFgERER8WkayRKROif7aDYRgRE0i2zmXvaLziOpn7WV/v89jcDjy9zLN9qSeDh0Btm2BMpKwTShXj3o3NkblYuIiIg/0EiWiNQZuSW5PLnoSTr/X2ee/PLJKuuM4mIGPfMugQf3A1BCEH9w/JE+gel850ygrMxqFxIC/fpBfHxtVy8iIiL+QiFLRK56LtPFu5nvEv/3eF5Jf4VyVzmzv5/N17u/rmgUFgavvQZA3o238eB13/NWo9/hCAsiJARCQyEmBpKT4amnNKmgiIiInJ8OFxSRq9o3e79h/MLxfHvgW/eyYEcwv6k3mG55YVUbDx8ODRsS2bcvT2UZNJgG69dDYaGVwbp3h9GjraAlIiIicj4KWSJyVcrMyWTS8knM3za/yvJhDfrw0j9zuWblP+GuUzB3bsVKw4CUFMAKUomJsGMH5OZCVBS0basRLBEREbk4haxqpKamkpqaitPp9HYpInIFnln8DM+vfr7Ksk4RbZmaHk3KnJUVC+fNg6wsSEqqdj82m869EhERkcun/8lWY9y4cWzevJl169Z5uxQRuQLXN7/e/bh5aBPeONiDzKd3kDKn4pBBOnaEzz6zhqtEREREPEgjWSLi1zYd3kSps5SusV3dywa3H8ydjfswYGMBD/8jk+CySlcOjouDKVPgF78Au90LFYuIiMjVTiFLRPyOaZp8ufNLXkl/hS93fklKyxSWjl7qXm8YBp/NcMGqjIqNGjSA3/4Wxo6FoCAvVC0iIiJ1hUKWiPiNkvISZmycwavpr/L9ke/dy5f9uIzMAxkkN60YzeLpp2HVKitcjR8PTzwBkZFeqFpERETqGoUsEfF5+/L28U7GO7z+7escLjxcZV0rM5pff2PS9rq9UDlk3XEHvP++NS17SEgtVywiIiJ1mUKWiPgsp8vJkNlDWLB9AS7TVWXdTXnRTPjiJHdln8RuAmYq3HZXRQObDe6/v3YLFhEREUEhS0R8hMt17jWp7DY7LtPlDlg202DYjgAmLC/luv0nKza22azRqlOndL6ViIiIeJ1ClkgdVF2g8eZFdhes3sPz8/7FpqLFxKXNJTw0gG7d4IEH4MHgG9lU+BVj1pXxy0yTuNzSig1bt4YHH4TRo6FZM6/VLyIiIlKZQpZIHZOZCe+9B6tXQ0EBhIfDTTfBmDGQnFx7dfx48kf+tflfTPt2DptOrIEwIAxM4zMcW4fyww+wcSNMfWIou176HTbz9IZBQXDPPfDQQ9C3r3fToYiIiEg1FLJE6pDMTHj4YcjOhrIya0TLZoOtWyEtDd5+u+aClmmaZB/NZv62+czZPId1B6q/2HdC4xfJ3DIUgIwMeH7OtXyYlAyhoXDvvTByJNSrVzNFioiIiHiAQpZIHeFywbPPWqNDpgnBwVbAcrmgpMRa/uyz8PnnNTM4dMfMO1iwfUG167ochOGbYdhmsB3PpXuoSbnToKQEli6FbQvTaJ8Y7PmiRERERGqAjrMRqSOys63LRpkmhIWBw2GFKYfDem6a1iGE2dlX/hqlzlK+2fsNf1/793PWdSmvX+V5Ug78eQls/RtseAN+txLaHHWQY2tGtD2fwEAwDDh+HDZsVcASERER/6GRLJE6YvFia8QqKMgKL5UZhrW8uNhql5BwafssKC0gfV86K3ev5Os9X7Nm3xqKy4sBuD08iTYJvdxtfxbelYwdH3DbDrhzG7Q9bi3fQRvecgxkedCtrHKkkG9YFww2sALgqVNw8OBP/elFREREao9Clp/wtdngxP8UF1ujVWcHrDMMw1pfXHz+fThdTj7c+CHrc9aTvu8bMnIycZrOatsuXPh3xlUKWb0GPMii4U9CRIQ1YcXAgSwov5V7nm4DQLCjam2mCeXlYLdDbOzl/rQiIiIi3qOQ5QcyM+H992HLFmskIjgYOnSwZq2uzdng5MqUl8OSJdZoTJMmcMst1ghNbevSBQICoLTUCi5nB5rSUmt9ly5QUl7C1qNbKXOV0b1pd3c7m2HjqbmPctQoqvY1rjkJvXdD7z1we+fSqisjIqwZNlq3dv+HoHU2xMRYhwSWllYcwuhyWe+baVpzXHTu7Ol3Q0RERKTmKGT5uMxMmDIFjhyB6GgrYDmd8O23sHs3TJqkoOXLZs6EF1+EvXut2fwCAqBFC5g4EUaMqN1aBgyAuDj44QfrELyAADAcpZRHbSU4Op2G9dIJbvEdv167ix1rjuEyTPrkRrPilRPufRiGQbeiSBaFWSGr4+GKUNV7N7QIamj9Qd6SBP37n1tE27ZVnsbHQ0oKLFhghazy8qrNQ0KgXz+rnYiIiIi/UMjyYS6XNYL144/WF/QdO6wvoQ4HNGgAhYUwfTokJurQQV80cyY8+aR1LaqICGtyifJy2LnTWg61ELRKSynO2UNAvYY4IqJ47jkYPx6iY/9CQb8pHI4qwWWDc8alTo9yZQSfxFVSjC04xL3q2bDbePqD9+kaeA0xCd3g+iQYmwxJSdC06fmPR6yGzQZPPw05ObBtmxX+zhzSGBRkhaunntLft4iIiPgXwzRN8+LN6qa8vDyioqLIzc0lMjKy1l9/2zbrkMCdO61AVfk3ZRjWl/Y2bawg5o3/9Os8sfMrL4cePWD7dmvEqPI1qc48j4+HtWsv49BBp9M6zq+SUx9O4+ChneSc3Me+/P3sKcphT/kx9hh57AkqYU+4kyNhsL7dS3S9z0p2M2fCm2+9wIq+/13tywSXwbVHodNh6JQbyPj/yyQkvtJMGPn5EBhopSAPycyEadNg/Xrrbz0sDLp31yGxIiIi4jsuJxtoJMuHnThhBazcXOu79dnnq+TmWutPnLj4vjwtMxPee8+a8rugAMLD4aabYMwY734p9nrwOz1bw/L5JeTvLKZZWRFh5UVEOIoJtRURYJay+NQtmKZ12N6SJTCwZJ41t3pBAWZBPgUFJzhScowjpSc4Wp7HEVcBR4xirm13A3e+87X7pZwuJ+Hbx1Buw+rJMadv1dhxcDNdTz8eMQI6xHel78fQ9rhB66IwugQ0oVNEazo27kzr9t2wt24DrVpZQ6Znj0xFRHj8bUtOtkZkFdpFRETkaqCQ5cOOH7cGDQD3NYPAClw2mzULXH6+1e6izgyDmWbVx2cvMwxrqKWyoiIrvZxut2ED/Hq8yfatJs5yE8N0kW+YzNgSRlpaCG+/fTpolZfDoUPWdpW2dz92uSpubdpYP+QZhw9bJ51VbuNyWaM5le9DQqBPH6BiNMS1ZBlR+fsICXTS+honN13vJK5puVVP5Vv37nDrrVXfo0cftYaZKt9KSytup05Z91OnwvXXV2y7aBHcfTelZSUUOkzig2BeMORGQ15Qxa3EZvD1diclpwyKi+HAAZiU/WfmFK/jRDicaACl5+mV9x3ZyZ2VntttdhqecpATUl5te5sLmp0KJM4VTlCrxlXWJSb140SrYxgxMZd1eF9Nstl07pWIiIhcHRSyfFh+vpUjznwHvr3sM6YVDgPAwHTf2+4AqHQsYXCwdcxVZWPHwptvXvxFhwyBTz+tuqxjR+vEsNMSgRXVbPqY83Xe2jiWZ5+Fzz8H286dcO21F39NsIZ1WrWqeD5rFjzxxMW3i4+HrVvJzIQJE6zJ69479gK9zUWU2qHsAJSthV12KLXDKcfpezs0GXo/bSqFLKfp4h/fvkGJHUocVttiBxQFQHEAFIVaj4sC4IW960isFLL+nbuWoU8VU2avrsgKwWUmEdvLKLUFunPikcByskMv/qMeiTx357c17UNeeQFNQhvTLCaOa5q0J65ZR+IatqVpRFMctuq7uGG3W9P2iYiIiIjHKWT5MJvNGtxxuazBk4KIg8xoVwaAaVixqvI9WI8d9lIePGtfywL38911525z5t51+nG7yP3cc9a2ryXkcqLl6TaV2rqMqrdjO3Zi7raOfMvOhpjyo/x+MDhPr3faTt+fflz5/t2iIzSmImTNLsvk1Yeg3GbdnEbF43IblNmt+zZFe/jaBf/7v5CRYQ08PXPvejLbXPz9/a+iDbxS6blhGPznHZf2u/mv4qMkVnoeFFnvogELoCQAwjhFWVkggYHWRX9/iLqe8OxsYgIiiQmOpkFoQxpGNqFhRGPrcVhDGoY2pGV0y3P29+74JZdWsIiIiIjUGoWsaqSmppKamorTWf1FVmtLp07WYENenjWatbfxIX455OLbBTtd54Ss2Y2O8ObtF992iDP3nJD11+RSfgyotnkVXfOLCTpoXctr8WIYOMDFO10vvh1AUVDVQ9YOxUawpuDi20VGRrBtGyxbZr2u3Q45tASOXnTb0k4dqjy3GTYCDAdlZvWH31Wpt0dSlecNEm8geXcyYYFhhAeGY54KY+3XkeQdicIsicRRHomtPBKzOJLckmAcdutyUfXrw5+uT+XPxusX/2FFRERExC8oZFVj3LhxjBs3zj2DiLfEx1uTSSxaZE16sTeq0yVtZwaem4iMpGRYv+ai27oSzj28z2jYCE7uuui2WxwdsRvWqU1FRWBvHHtJ9QI461WdscHetj1sB7thx2Fz4LA5sNvsBNgC3M8dNgfNYlqxcaN1XpphWCN/J44NwBEYAc5AcAXgKgsAZyC9bgiifZsgAu2BBNmD6BXX65w63rnrXRw2B8GOYIIdwQQ5gggNCK1yC3GEEBFUdfKHrrFdyXgkw/3c5YIJG+GLNDh2zJocxHl6dsGocCtc3XKLNbmD4SPnRImIiIiIZyhk+bCzryHkOpRExIo3MLC+mDdubHDvzw3i4sDAwDAMDAzstnOPWxuTPIZecb2wGTZ3u8r3NsOGzbARG35uMHrvrvc45TyFgcG362xMfs7AdNoICjQwsINpA9OGkduSU6XWvBmJiRAXFcemsZuwGTbsNrt1b9jdz+2G3X0fHRxd5TUf7fEoj/Z49JICyNSpVqgJCrKCVkja/1RZX1ZmzVcx9CYYf+d5dnLaqMRRF329S2GzWdOP795tzeHhcFRc/6m8HBo1gvvv1+x5IiIiIlcjXSfrArx9nawzfOkaQuXl1jwYP/xgBYeAgIpp5cvKrPVt2sCmTZdx/aefaM4cGHU6GwUHV50szzStwwgBPvgAhg+vnZrOyMy0rmO2ZYtVR3CwdR7W/ffr+k8iIiIi/kTXybrK+NI1hBwOeO45ePxx61yxM6MzZ2Zkj4qCyZNrL2ABdO4MMTHWIYOlpedeT8w0rXPbOneuvZrO8KXfnYiIiIjUDoUsP+FL1xAaMcK6f/FFa2b3sjJrRKtlS5g4sWJ9bYmPh5QUWLDAClnlZ81bERIC/fp57/3zpd+diIiIiNQ8hSy5IiNGWIfeLVkCBw9CkybWRA61OYJ1xtnnrp06VTHCFhRkBZynntLokYiIiIjUDp2TdQG+ck6WXBpfOndNRERERK4uOidL6iSd/yQiIiIivkAhS64qOv9JRERERLxN/+MXERERERHxIIUsERERERERD1LIEhERERER8SCFLBEREREREQ9SyBIREREREfEghSwREREREREPUsgSERERERHxIIUsERERERERD1LIEhERERER8SCFLBEREREREQ9SyBIREREREfEghSwREREREREPUsgSERERERHxIIe3C/BlpmkCkJeX5+VKRERERETEm85kgjMZ4UIUsi4gPz8fgBYtWni5EhERERER8QX5+flERUVdsI1hXkoUq6NcLhcHDhwgIiICwzAuebsePXqwbt06j7fPy8ujRYsW7N27l8jIyEvef11wue+5t3ijzpp8TU/t+6fu50q3V1+tfeqr3nlN9dVzqZ9emD/0VW/VqL7qmW388TPVNE3y8/Np2rQpNtuFz7rSSNYF2Gw2mjdvftnb2e32y/ojuNz2kZGRXv8j8zWX+x56izfqrMnX9NS+f+p+rnR79dXap77qnddUXz0/9dPq+UNf9VaN6que2cZfP1MvNoJ1hia+qAHjxo2r0fZyLn95D71RZ02+pqf2/VP3c6Xbq6/WPn95D9VXa2Y/6qv+wx/eQ2/VqL7qmW384W/sp9Dhgn4kLy+PqKgocnNzfSLJi0j11FdFfJ/6qYh/8Ne+qpEsPxIUFMTkyZMJCgrydikicgHqqyK+T/1UxD/4a1/VSJaIiIiIiIgHaSRLRERERETEgxSyREREREREPEghS0RERERExIMUskRERERERDxIIUtERERERMSDFLKuQnv37qVv374kJCTQpUsX5syZ4+2SROQ87r77bmJiYhg2bJi3SxGRSubPn0/79u1p164d//jHP7xdjoich69+jmoK96tQTk4Ohw4dIikpiYMHD9KtWze2bdtGWFiYt0sTkbMsX76c/Px83n//fT7++GNvlyMiQHl5OQkJCSxbtoyoqCi6detGWloa9evX93ZpInIWX/0c1UjWVSg2NpakpCQAmjRpQoMGDTh+/Lh3ixKRavXt25eIiAhvlyEilaxdu5aOHTvSrFkzwsPDuf322/nyyy+9XZaIVMNXP0cVsrxg5cqV3HnnnTRt2hTDMJg7d+45bVJTU2nZsiXBwcFcd911rF279opea/369TidTlq0aPETqxape2qzr4qI5/zUvnvgwAGaNWvmft6sWTP2799fG6WL1ClX8+esQpYXFBYWkpiYSGpqarXrZ8+ezYQJE5g8eTIZGRkkJiYycOBADh8+7G6TlJREp06dzrkdOHDA3eb48ePcf//9vPXWWzX+M4lcjWqrr4qIZ3mi74pIzbuq+6opXgWYn376aZVlPXv2NMeNG+d+7nQ6zaZNm5p/+ctfLnm/JSUlZu/evc3p06d7qlSROq2m+qppmuayZcvMoUOHeqJMETnLlfTd1atXm0OGDHGvf+KJJ8wZM2bUSr0iddVP+Zz1xc9RjWT5mNLSUtavX0///v3dy2w2G/379+ebb765pH2YpskDDzxAv379GDVqVE2VKlKneaKvikjtu5S+27NnTzZt2sT+/fspKCjgiy++YODAgd4qWaRO8vfPWYUsH3P06FGcTieNGzeusrxx48YcPHjwkvaxevVqZs+ezdy5c0lKSiIpKYnvvvuuJsoVqbM80VcB+vfvz/Dhw1mwYAHNmzf3iw8OEX92KX3X4XDw8ssvk5KSQlJSEk8++aRmFhSpZZf6Oeurn6MObxcgnterVy9cLpe3yxCRS7B48WJvlyAi1Rg8eDCDBw/2dhkichG++jmqkSwf06BBA+x2O4cOHaqy/NChQzRp0sRLVYnI2dRXRfyT+q6If/D3vqqQ5WMCAwPp1q0bS5YscS9zuVwsWbKEG264wYuViUhl6qsi/kl9V8Q/+Htf1eGCXlBQUMCOHTvcz3ft2kVWVhb16tUjLi6OCRMmMHr0aLp3707Pnj157bXXKCwsZMyYMV6sWqTuUV8V8U/quyL+4aruq96e3rAuWrZsmQmccxs9erS7zd/+9jczLi7ODAwMNHv27Gmmp6d7r2CROkp9VcQ/qe+K+Ierua8apmmatRvrRERERERErl46J0tERERERMSDFLJEREREREQ8SCFLRERERETEgxSyREREREREPEghS0RERERExIMUskRERERERDxIIUtERERERMSDFLJEREREREQ8SCFLRETkMhiGwdy5c71dhoiI+DCFLBER8StOp5Mbb7yRe+65p8ry3NxcWrRowW9/+1svVSYiImJRyBIREb9it9uZNm0aCxcuZMaMGe7ljz/+OPXq1WPy5MlerE5EREQhS0RE/FB8fDzPP/88jz/+ODk5OcybN49Zs2Yxffp0AgMDq93m2Wef5brrrjtneWJiIlOmTAFg3bp1DBgwgAYNGhAVFcXNN99MRkbGeetYvnw5hmFw8uRJ97KsrCwMw+DHH390L1u1ahW9e/cmJCSEFi1aMH78eAoLC93rX3/9ddq1a0dwcDCNGzdm2LBhl/mOiIiIL1HIEhERv/T444+TmJjIqFGj+NWvfsWkSZNITEw8b/uRI0eydu1adu7c6V72/fffs3HjRu677z4A8vPzGT16NKtWrSI9PZ127doxaNAg8vPzr7jOnTt3cttttzF06FA2btzI7NmzWbVqFY899hgA3377LePHj2fKlCls3bqVhQsX0qdPnyt+PRER8T7DNE3T20WIiIhciezsbDp06EDnzp3JyMjA4XBcsH1SUhJDhw7l97//PWCNbi1dupT09PRq27tcLqKjo/noo4+44447AGvii08//ZQhQ4awfPlyUlJSOHHiBNHR0YA1kpWcnMyuXbto2bIlDz30EHa7nTfffNO931WrVnHzzTdTWFjIggULGDNmDPv27SMiIsID74qIiHibRrJERMRvvfvuu4SGhrJr1y727dt30fYjR47ko48+AsA0TWbOnMnIkSPd6w8dOsTDDz9Mu3btiIqKIjIykoKCAvbs2XPFNW7YsIFp06YRHh7uvg0cOBCXy8WuXbsYMGAA11xzDa1bt2bUqFHMmDGDoqKiK349ERHxPoUsERHxS2lpabz66qvMnz+fnj178uCDD3KxgzNGjBjB1q1bycjIIC0tjb1793Lvvfe6148ePZqsrCz++te/kpaWRlZWFvXr16e0tLTa/dls1sdo5dctKyur0qagoIBHHnmErKws923Dhg1s376dNm3aEBERQUZGBjNnziQ2NtZ92GPl87xERMS/XPi4ChERER9UVFTEAw88wNixY0lJSaFVq1Z07tyZN954g7Fjx553u+bNm3PzzTczY8YMiouLGTBgAI0aNXKvX716Na+//jqDBg0CYO/evRw9evS8+2vYsCEAOTk5xMTEANbhgpV17dqVzZs307Zt2/Pux+Fw0L9/f/r378/kyZOJjo5m6dKl50xTLyIi/kEjWSIi4neeeeYZTNPk+eefB6Bly5a89NJLTJw4scqsftUZOXIks2bNYs6cOVUOFQRo164dH3zwAVu2bGHNmjWMHDmSkJCQ8+6rbdu2tGjRgueee47t27fz+eef8/LLL1dp85vf/Ia0tDQee+wxsrKy2L59O/PmzXNPfDF//nymTp1KVlYWu3fvZvr06bhcLtq3b38F74yIiPgChSwREfErK1asIDU1lffee4/Q0FD38kceeYQbb7zxoocNDhs2jGPHjlFUVMSQIUOqrHvnnXc4ceIEXbt2ZdSoUYwfP77KSNfZAgICmDlzJtnZ2XTp0oUXXniBP/3pT1XadOnShRUrVrBt2zZ69+5NcnIykyZNomnTpgBER0fzySef0K9fPzp06MAbb7zBzJkz6dix4xW8OyIi4gs0u6CIiIiIiIgHaSRLRERERETEgxSyREREREREPEghS0RERERExIMUskRERERERDxIIUtERERERMSDFLJEREREREQ8SCFLRERERETEgxSyREREREREPEghS0RERERExIMUskRERERERDxIIUtERERERMSDFLJEREREREQ86P8BkE3zkHnkYHAAAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 42
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "While somewhat subtle, close observation reveals superior performance of the 5PL model for higher concentration samples. You should expect to see similar performance when your data has high levels of asymmetry.\n",
+    "\n",
+    "With our model succesfully fit, we can now predict concentrations of new data.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-20T08:35:08.773834Z",
+     "start_time": "2024-11-20T08:35:08.768413Z"
+    }
+   },
+   "source": [
+    "newly_measured_responses = [0.005, 0.0124, 2.14, 1.10, 0.872]\n",
+    "five_pl_model.predict_inverse(newly_measured_responses)"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.11554827, 0.17327293, 2.74689818, 1.1411622 , 0.96045729])"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 45
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we use the `predict_inverse()` function because we are predicting the concentration of the unknown samples from the measured signal. I.e. given the plots above, we've measured new values of $y$ (instrument response) and want to predict the corresponding values of $x$ (analyte concentration)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION

Summary
---
Adds code in `logistic.py` to enable fitting a 5 parameter logistic model to provided data. The code template borrows very heavily from the initial 4 parameter logistic implementation.


Testing
---
Unit tests remain to be added in a follow up MR. To verify performance of the current code, it is easiest to walk through the accompanying 5PL notebook in the examples directory. Alternatively, one can generate 5PL based data and run the following code snippet:

from bio_curve_fit.logistic import FourPLLogistic, FivePLLogistic

```
x_data = {your_x_data}
y_data = {your_y_data}

five_PL_model = FivePLLogistic()
five_PL_model.fit(x_data, y_data, weight_func = lambda x:x)
five_PL_data = five_PL_model.predict(smoothed_x_values)
```

Follow Ups

1. Add appropriate unit tests for 5PL code.
2. Refactor logistic.py to minimize copy pasted code/generalize more

