### PR TITLE
Add parameter constraints to FourParamLogistic for 3PL regression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Setup
+```bash
+poetry install       # Install dependencies
+poetry shell        # Activate virtual environment
+pre-commit install  # Install pre-commit hooks
+```
+
+### Testing
+```bash
+poetry run pytest                    # Run all tests
+poetry run pytest tests/test_*.py    # Run specific test file
+poetry run pytest -k "test_name"    # Run tests matching pattern
+coverage run -m pytest && coverage report  # Run tests with coverage
+```
+
+### Code Quality
+```bash
+poetry run ruff check               # Lint code
+poetry run ruff check --fix         # Auto-fix linting issues
+poetry run mypy bio_curve_fit/      # Type checking
+poetry run isort bio_curve_fit/     # Sort imports
+```
+
+## Architecture
+
+This is a Python package that provides curve fitting algorithms for biological assays, following the scikit-learn API pattern.
+
+### Core Structure
+- `bio_curve_fit/base.py`: Abstract base class `BaseStandardCurve` defining the interface for all curve models
+- `bio_curve_fit/logistic.py`: Contains `LogisticRegression` abstract base class and concrete implementations (`FourParamLogistic`, `FiveParamLogistic`)
+- `bio_curve_fit/plotting.py`: Plotting utilities for visualizing curves and limits of detection
+
+### Key Concepts
+- All models inherit from `BaseStandardCurve` and implement `predict()` and `predict_inverse()` methods
+- Models follow scikit-learn conventions with `fit()`, `predict()`, and parameter attributes ending in `_`
+- Limits of Detection (LOD) are calculated automatically: `LLOD`/`ULOD` for concentration, `LLOD_y_`/`ULOD_y_` for response
+- Uses scipy.optimize.curve_fit for non-linear regression with optional inverse variance weighting
+
+### Model Usage Pattern
+```python
+model = FourParamLogistic()
+model.fit(concentrations, responses)
+predictions = model.predict(new_concentrations)        # Forward prediction
+concentrations = model.predict_inverse(new_responses)  # Inverse prediction
+```
+
+The package is designed for biologists with minimal programming experience, so examples should be simple and well-documented.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Setup
 ```bash
-poetry install       # Install dependencies
+poetry install       # Install all dependencies including dev deps (creates .venv if it doesn't exist)
 poetry shell        # Activate virtual environment
 pre-commit install  # Install pre-commit hooks
 ```
+
+**Important Notes:**
+- If `.venv` directory doesn't exist, `poetry install` will create it automatically
+- `poetry install` installs both main and dev dependencies by default
+- Always activate the virtual environment before running git commands to ensure pre-commit hooks work properly
+- When creating PRs, remember to update the version in `pyproject.toml`
 
 ### Testing
 ```bash

--- a/examples/four_pl_logistic/four_pl_fit.ipynb
+++ b/examples/four_pl_logistic/four_pl_fit.ipynb
@@ -599,6 +599,69 @@
    "source": [
     "Note that we use the `predict_inverse()` function because we are predicting the concentration of the unknown samples from the measured signal. I.e. given the plots above, we've measured new values of $y$ (instrument response) and want to predict the corresponding values of $x$ (analyte concentration)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Parameter Constraints: Creating a 3PL Model\n\nThe `FourParamLogistic` class supports parameter constraints by fixing specific parameters during initialization. \nThis is useful when you want to create models with fewer free parameters, such as a 3-parameter logistic (3PL) model.\n\nFor example, to create a 3PL model where the Hill's slope (B parameter) is fixed to 1.0:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a 3PL model by fixing the Hill's slope (B) to 1.0\n",
+    "model_3pl = FourParamLogistic(B=1.0)\n",
+    "model_3pl.fit(x, y, weight_func=FourParamLogistic.inverse_variance_weight_function)\n",
+    "\n",
+    "print(\"3PL Model Parameters:\")\n",
+    "print(f\"  A (min asymptote): {model_3pl.A:.2f}\")\n",
+    "print(f\"  B (Hill slope): {model_3pl.B:.2f} (fixed)\")\n",
+    "print(f\"  C (EC50): {model_3pl.C:.2f}\")\n",
+    "print(f\"  D (max asymptote): {model_3pl.D:.2f}\")\n",
+    "print(f\"\\n3PL R² score: {model_3pl.score(x, y):.6f}\")\n",
+    "\n",
+    "# Compare with the unconstrained 4PL model\n",
+    "print(f\"\\nFor comparison, unconstrained 4PL:\")\n",
+    "print(f\"  A (min asymptote): {model2.A:.2f}\")\n",
+    "print(f\"  B (Hill slope): {model2.B:.2f}\")\n",
+    "print(f\"  C (EC50): {model2.C:.2f}\")\n",
+    "print(f\"  D (max asymptote): {model2.D:.2f}\")\n",
+    "print(f\"\\n4PL R² score: {model2.score(x, y):.6f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot both models for comparison\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "\n",
+    "# Plot 4PL model\n",
+    "plot_standard_curve(\n",
+    "    x, y, model2, title=\"4PL Model (B unconstrained)\", show_plot=False, ax=ax1\n",
+    ")\n",
+    "\n",
+    "# Plot 3PL model\n",
+    "plot_standard_curve(\n",
+    "    x, y, model_3pl, title=\"3PL Model (B=1.0 fixed)\", show_plot=False, ax=ax2\n",
+    ")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"\\\\nOther parameter constraint examples:\")\n",
+    "print(\"- Fix minimum asymptote: FourParamLogistic(A=400)\")\n",
+    "print(\"- Fix multiple parameters: FourParamLogistic(A=400, D=1000000)\")\n",
+    "print(\n",
+    "    \"- All parameters fixed (no fitting): FourParamLogistic(A=400, B=1.0, C=1000, D=1000000)\"\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bio-curve-fit"
-version = "1.0.1"
+version = "1.0.2"
 description = "Curve fitting algorithms for bio-assays with scikit-learn api"
 authors = ["Luke Schiefelbein <luke@ganymede.bio>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Enhanced FourParamLogistic to support fixing any combination of A, B, C, D parameters
- Users can create 3PL models with FourParamLogistic(B=1.0) or other constraint combinations
- Added comprehensive tests and Jupyter notebook examples

## Test plan
- [x] Added unit tests for parameter constraints
- [x] All existing tests pass
- [x] Fixed flaky plot comparison test

🤖 Generated with [Claude Code](https://claude.ai/code)